### PR TITLE
CLI: add --path to allow choosing a project path 

### DIFF
--- a/crates/domino/src/cli.rs
+++ b/crates/domino/src/cli.rs
@@ -14,7 +14,7 @@ pub(crate) enum Commands {
     /// Reformat file or directory
     Format(Format),
 
-    Proofsteps,
+    Proofsteps(Proofsteps),
 }
 
 #[derive(clap::Args, Debug)]
@@ -22,6 +22,10 @@ pub(crate) enum Commands {
 pub(crate) struct Format {
     /// Input to reformat
     pub(crate) input: Option<std::path::PathBuf>,
+    /// Path to the Domino project (or a subdirectory of it) to reformat when no input is given.
+    /// Defaults to searching the current directory and its ancestors for an `ssp.toml`.
+    #[clap(long, short = 'p')]
+    pub(crate) project: Option<std::path::PathBuf>,
 }
 
 #[derive(clap::Args, Debug)]
@@ -31,11 +35,19 @@ pub(crate) struct Latex {
     #[clap(short, long, default_value = "z3")]
     pub(crate) smtsolver: Option<SolverVariant>,
     // TODO: given we have a default here, it seems impossible to choose none
+    /// Path to the Domino project (or a subdirectory of it). Defaults to searching the current
+    /// directory and its ancestors for an `ssp.toml`.
+    #[clap(long, short = 'p')]
+    pub(crate) project: Option<std::path::PathBuf>,
 }
 
 #[derive(clap::Args, Debug)]
 #[clap(author, version, about, long_about = None)]
 pub(crate) struct Prove {
+    /// Path to the Domino project (or a subdirectory of it). Defaults to searching the current
+    /// directory and its ancestors for an `ssp.toml`.
+    #[clap(long, short = 'p')]
+    pub(crate) project: Option<std::path::PathBuf>,
     #[clap(short, long, default_value = "cvc5")]
     pub(crate) smtsolver: SolverVariant,
     #[clap(short, long)]
@@ -48,4 +60,13 @@ pub(crate) struct Prove {
     pub(crate) oracle: Option<String>,
     #[clap(long, default_value_t = 1)]
     pub(crate) parallel: usize,
+}
+
+#[derive(clap::Args, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub(crate) struct Proofsteps {
+    /// Path to the Domino project (or a subdirectory of it). Defaults to searching the current
+    /// directory and its ancestors for an `ssp.toml`.
+    #[clap(long, short = 'p')]
+    pub(crate) project: Option<std::path::PathBuf>,
 }

--- a/crates/domino/src/cli.rs
+++ b/crates/domino/src/cli.rs
@@ -14,7 +14,7 @@ pub(crate) enum Commands {
     /// Reformat file or directory
     Format(Format),
 
-    Proofsteps,
+    Proofsteps(Proofsteps),
 }
 
 #[derive(clap::Args, Debug)]
@@ -28,14 +28,22 @@ pub(crate) struct Format {
 #[clap(author, version, about, long_about = None)]
 pub(crate) struct Latex {
     /// Solver for graph layouting
+    /// TODO: given we have a default here, it seems impossible to choose none
     #[clap(short, long, default_value = "z3")]
     pub(crate) smtsolver: Option<SolverVariant>,
-    // TODO: given we have a default here, it seems impossible to choose none
+    /// Path to the Domino project. Defaults to searching the current
+    /// directory and its ancestors for an `ssp.toml`.
+    #[clap(long)]
+    pub(crate) path: Option<std::path::PathBuf>,
 }
 
 #[derive(clap::Args, Debug)]
 #[clap(author, version, about, long_about = None)]
 pub(crate) struct Prove {
+    /// Path to the Domino project. Defaults to searching the current
+    /// directory and its ancestors for an `ssp.toml`.
+    #[clap(long)]
+    pub(crate) path: Option<std::path::PathBuf>,
     #[clap(short, long, default_value = "cvc5")]
     pub(crate) smtsolver: SolverVariant,
     #[clap(short, long)]
@@ -50,4 +58,13 @@ pub(crate) struct Prove {
     pub(crate) claim: Option<String>,
     #[clap(long, default_value_t = 1)]
     pub(crate) parallel: usize,
+}
+
+#[derive(clap::Args, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub(crate) struct Proofsteps {
+    /// Path to the Domino project. Defaults to searching the current
+    /// directory and its ancestors for an `ssp.toml`.
+    #[clap(long)]
+    pub(crate) path: Option<std::path::PathBuf>,
 }

--- a/crates/domino/src/main.rs
+++ b/crates/domino/src/main.rs
@@ -40,19 +40,25 @@ enum Error {
     IncompatibleArgumentsErrorError(#[from] IncompatibleArgumentsError),
 }
 
-fn proofsteps() -> Result<(), Error> {
-    let project_root = project::directory::find_project_root()?;
+fn proofsteps(p: &Proofsteps) -> Result<(), Error> {
+    let project_root = p
+        .path
+        .to_owned()
+        .unwrap_or(project::directory::find_project_root()?);
     let files = project::DirectoryFiles::load(&project_root)?;
-    let project = project::DirectoryProject::load(&files)?;
+    let project = project::DirectoryProject::load(project_root, &files)?;
 
     project.proofsteps()?;
     Ok(())
 }
 
 fn prove(p: &Prove) -> Result<(), Error> {
-    let project_root = project::directory::find_project_root()?;
+    let project_root = p
+        .path
+        .to_owned()
+        .unwrap_or(project::directory::find_project_root()?);
     let files = project::DirectoryFiles::load(&project_root)?;
-    let project = project::DirectoryProject::load(&files)?;
+    let project = project::DirectoryProject::load(project_root, &files)?;
 
     if p.proofstep.is_none() || p.proof.is_some() {
         let smtsolver =
@@ -73,9 +79,12 @@ fn prove(p: &Prove) -> Result<(), Error> {
 }
 
 fn latex(l: &Latex) -> Result<(), Error> {
-    let project_root = project::directory::find_project_root()?;
+    let project_root = l
+        .path
+        .to_owned()
+        .unwrap_or(project::directory::find_project_root()?);
     let files = project::DirectoryFiles::load(&project_root)?;
-    let project = project::DirectoryProject::load(&files)?;
+    let project = project::DirectoryProject::load(project_root, &files)?;
 
     let smtsolver = l
         .smtsolver
@@ -108,7 +117,7 @@ fn main() -> miette::Result<()> {
 
     let result = match &cli.command {
         Commands::Prove(p) => prove(p),
-        Commands::Proofsteps => proofsteps(),
+        Commands::Proofsteps(p) => proofsteps(p),
         Commands::Latex(l) => latex(l),
         Commands::Format(f) => format(f),
     };

--- a/crates/domino/src/main.rs
+++ b/crates/domino/src/main.rs
@@ -40,19 +40,19 @@ enum Error {
     IncompatibleArgumentsErrorError(#[from] IncompatibleArgumentsError),
 }
 
-fn proofsteps() -> Result<(), Error> {
-    let project_root = project::directory::find_project_root()?;
+fn proofsteps(p: &Proofsteps) -> Result<(), Error> {
+    let project_root = project::directory::find_project_root(p.project.as_deref())?;
     let files = project::DirectoryFiles::load(&project_root)?;
-    let project = project::DirectoryProject::load(&files)?;
+    let project = project::DirectoryProject::load(project_root, &files)?;
 
     project.proofsteps()?;
     Ok(())
 }
 
 fn prove(p: &Prove) -> Result<(), Error> {
-    let project_root = project::directory::find_project_root()?;
+    let project_root = project::directory::find_project_root(p.project.as_deref())?;
     let files = project::DirectoryFiles::load(&project_root)?;
-    let project = project::DirectoryProject::load(&files)?;
+    let project = project::DirectoryProject::load(project_root, &files)?;
 
     if p.proofstep.is_none() || p.proof.is_some() {
         let smtsolver =
@@ -72,9 +72,9 @@ fn prove(p: &Prove) -> Result<(), Error> {
 }
 
 fn latex(l: &Latex) -> Result<(), Error> {
-    let project_root = project::directory::find_project_root()?;
+    let project_root = project::directory::find_project_root(l.project.as_deref())?;
     let files = project::DirectoryFiles::load(&project_root)?;
-    let project = project::DirectoryProject::load(&files)?;
+    let project = project::DirectoryProject::load(project_root, &files)?;
 
     let smtsolver = l
         .smtsolver
@@ -87,7 +87,7 @@ fn format(f: &Format) -> Result<(), Error> {
     if let Some(input) = &f.input {
         sspverif::format::format_file(input)?;
     } else {
-        let root = crate::project::directory::find_project_root();
+        let root = crate::project::directory::find_project_root(f.project.as_deref());
         sspverif::format::format_file(&root?)?;
     }
     Ok(())
@@ -107,7 +107,7 @@ fn main() -> miette::Result<()> {
 
     let result = match &cli.command {
         Commands::Prove(p) => prove(p),
-        Commands::Proofsteps => proofsteps(),
+        Commands::Proofsteps(p) => proofsteps(p),
         Commands::Latex(l) => latex(l),
         Commands::Format(f) => format(f),
     };

--- a/src/project/directory.rs
+++ b/src/project/directory.rs
@@ -67,9 +67,7 @@ impl<'a> DirectoryProject<'a> {
         }
     }
 
-    pub fn load(files: &'a DirectoryFiles) -> Result<DirectoryProject<'a>> {
-        let root_dir = find_project_root()?;
-
+    pub fn load(root_dir: PathBuf, files: &'a DirectoryFiles) -> Result<DirectoryProject<'a>> {
         let packages = super::load::packages(&files.packages)?;
         let games = super::load::games(&files.games, &packages)?;
         let theorems =

--- a/src/project/directory.rs
+++ b/src/project/directory.rs
@@ -67,9 +67,7 @@ impl<'a> DirectoryProject<'a> {
         }
     }
 
-    pub fn load(files: &'a DirectoryFiles) -> Result<DirectoryProject<'a>> {
-        let root_dir = find_project_root()?;
-
+    pub fn load(root_dir: PathBuf, files: &'a DirectoryFiles) -> Result<DirectoryProject<'a>> {
         let packages = super::load::packages(&files.packages)?;
         let games = super::load::games(&files.games, &packages)?;
         let theorems =
@@ -118,8 +116,15 @@ impl Project for DirectoryProject<'_> {
     }
 }
 
-pub fn find_project_root() -> std::result::Result<std::path::PathBuf, super::error::Error> {
-    let mut dir = std::env::current_dir().map_err(FindProjectRootError::CurrentDir)?;
+/// Finds the root of the Domino project (the directory containing `ssp.toml`) by searching
+/// `start_dir` and its ancestors. If `start_dir` is `None`, searches from the current directory.
+pub fn find_project_root(
+    start_dir: Option<&Path>,
+) -> std::result::Result<std::path::PathBuf, super::error::Error> {
+    let mut dir = match start_dir {
+        Some(path) => path.to_path_buf(),
+        None => std::env::current_dir().map_err(FindProjectRootError::CurrentDir)?,
+    };
 
     loop {
         let lst = dir.read_dir().map_err(FindProjectRootError::ReadDir)?;


### PR DESCRIPTION
Add optional `--path` on sub commands `prove`, `proofsteps`, and `latex` to choose a Domino project by the path of the directory containing `ssp.toml`.