### PR TITLE
Check package invariants once

### DIFF
--- a/crates/domino/src/cli.rs
+++ b/crates/domino/src/cli.rs
@@ -48,14 +48,24 @@ pub(crate) struct Prove {
     pub(crate) smtsolver: SolverVariant,
     #[clap(short, long)]
     pub(crate) transcript: bool,
+    /// Only prove that the invariants hold in the initial state.
+    /// Also restricts package invariants to their induction start.
     #[clap(long)]
     pub(crate) invariant_start: bool,
     #[clap(long)]
     pub(crate) proofstep: Option<usize>,
     #[clap(long)]
     pub(crate) proof: Option<String>,
+    /// Only prove the invariant of this package, and nothing else.
+    /// Cannot be combined with --proof or --proofstep.
+    #[clap(long)]
+    pub(crate) package: Option<String>,
+    /// Only prove the claims of this oracle. Package invariants are then only checked for
+    /// packages that have an oracle of this name, and only for that oracle.
     #[clap(long)]
     pub(crate) oracle: Option<String>,
+    /// Only prove the equivalence claims whose name matches this pattern.
+    /// Does not apply to package invariants.
     #[clap(long)]
     pub(crate) claim: Option<String>,
     #[clap(long, default_value_t = 1)]

--- a/crates/domino/src/main.rs
+++ b/crates/domino/src/main.rs
@@ -30,6 +30,16 @@ pub(crate) struct Cli {
 pub struct IncompatibleArguments;
 
 #[derive(Error, Diagnostic, Debug)]
+#[error("--package cannot be combined with --proof or --proofstep")]
+#[diagnostic(help(
+    "a package invariant is proved on its own, for arbitrary package constants, so it is not \
+        part of any particular theorem or proof step. Drop --proof/--proofstep to check just \
+        the package, or drop --package to prove the theorem (its package invariants are \
+        checked along with it)."
+))]
+pub struct PackageWithProof;
+
+#[derive(Error, Diagnostic, Debug)]
 #[error("--oracle and --invariant-start cannot be used together")]
 #[diagnostic(help(
     "--invariant-start restricts verification to the invariant start, which \
@@ -51,6 +61,9 @@ enum Error {
     #[error(transparent)]
     #[diagnostic(transparent)]
     ReqOracleWithInvariantStart(#[from] ReqOracleWithInvariantStart),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    PackageWithProof(#[from] PackageWithProof),
 }
 
 fn proofsteps(p: &Proofsteps) -> Result<(), Error> {
@@ -81,7 +94,24 @@ fn prove(p: &Prove) -> Result<(), Error> {
         return Err(ReqOracleWithInvariantStart.into());
     }
 
+    if p.package.is_some() && (p.proof.is_some() || p.proofstep.is_some()) {
+        return Err(PackageWithProof.into());
+    }
+
     let smtsolver = sspverif::util::smtsolver::process::ProcessSmtSolverBackend::new(p.smtsolver);
+
+    if let Some(package) = &p.package {
+        project.prove_package(
+            &smtsolver,
+            p.transcript,
+            p.parallel,
+            package,
+            &p.oracle,
+            p.invariant_start,
+        )?;
+        return Ok(());
+    }
+
     project.prove(
         &smtsolver,
         p.transcript,

--- a/src/gamehops/equivalence/error.rs
+++ b/src/gamehops/equivalence/error.rs
@@ -103,6 +103,13 @@ pub enum Error {
     RewriteNeedsGameContext { defn: String },
     #[error("define-package-invariant only valid in package contexts: {defn}")]
     RewriteNeedsPackageContext { defn: String },
+    #[error("{defn} is only valid in the invariant file of an equivalence")]
+    #[diagnostic(help(
+        "package invariant files are also used when proving the package invariant on its own, \
+         where there is no second game to relate to. Move this definition into the invariant \
+         file of the equivalence that needs it."
+    ))]
+    RewriteNeedsEquivalenceContext { defn: String },
     #[error(transparent)]
     ParserError(#[from] crate::util::smtparser::Error),
     #[error("SMT Solver failed in claim {claim_name} when verifying {claim_group_name}")]

--- a/src/gamehops/equivalence/mod.rs
+++ b/src/gamehops/equivalence/mod.rs
@@ -12,7 +12,7 @@ use crate::{
 use error::{Error, ExportSignatureMismatch, Result};
 
 pub mod error;
-mod smtrewrite;
+pub(crate) mod smtrewrite;
 mod verify_fn;
 
 pub(crate) use verify_fn::EquivalenceSmtDriver;

--- a/src/gamehops/equivalence/smtrewrite.rs
+++ b/src/gamehops/equivalence/smtrewrite.rs
@@ -7,6 +7,7 @@ use crate::util::smtparser::SmtParser;
 use crate::writers::smt::contexts::GameInstanceContext;
 use crate::writers::smt::exprs::SmtExpr;
 use crate::writers::smt::exprs::SmtLet;
+use crate::writers::smt::names;
 use crate::writers::smt::patterns;
 use crate::writers::smt::patterns::datastructures::DatastructurePattern;
 
@@ -14,7 +15,9 @@ use crate::gamehops::equivalence::error::{Error, Result};
 use itertools::Itertools;
 
 struct SmtRewrite<'a> {
-    context: &'a EquivalenceContext<'a>,
+    /// Absent when rewriting the invariant of a package on its own, i.e. outside of an
+    /// equivalence. Definitions that talk about two games are then rejected.
+    context: Option<&'a EquivalenceContext<'a>>,
     package: Option<&'a PackageInstance>,
     game: Option<&'a GameInstance>,
     content: Vec<SmtExpr>,
@@ -23,7 +26,7 @@ struct SmtRewrite<'a> {
 impl<'a> SmtRewrite<'a> {
     fn new(context: &'a EquivalenceContext) -> Self {
         Self {
-            context,
+            context: Some(context),
             package: None,
             game: None,
             content: Vec::new(),
@@ -32,7 +35,7 @@ impl<'a> SmtRewrite<'a> {
 
     fn new_with_game(context: &'a EquivalenceContext, game: &'a GameInstance) -> Self {
         Self {
-            context,
+            context: Some(context),
             package: None,
             game: Some(game),
             content: Vec::new(),
@@ -45,11 +48,29 @@ impl<'a> SmtRewrite<'a> {
         package: &'a PackageInstance,
     ) -> Self {
         Self {
-            context,
+            context: Some(context),
             package: Some(package),
             game: Some(game),
             content: Vec::new(),
         }
+    }
+
+    fn new_standalone_package(game: &'a GameInstance, package: &'a PackageInstance) -> Self {
+        Self {
+            context: None,
+            package: Some(package),
+            game: Some(game),
+            content: Vec::new(),
+        }
+    }
+
+    /// The equivalence we are rewriting for, or an error if we are rewriting a package invariant
+    /// on its own.
+    fn context(&self, defn: &str) -> Result<&'a EquivalenceContext<'a>> {
+        self.context
+            .ok_or_else(|| Error::RewriteNeedsEquivalenceContext {
+                defn: defn.to_string(),
+            })
     }
 }
 
@@ -132,11 +153,14 @@ fn gen_varbinding(package: &PackageInstance, package_state: &str) -> Vec<(String
 
 impl SmtRewrite<'_> {
     fn equivalence_name(&self) -> String {
-        format!(
-            "{} = {}",
-            self.context.equivalence().left_name,
-            self.context.equivalence().right_name
-        )
+        match self.context {
+            Some(context) => format!(
+                "{} = {}",
+                context.equivalence().left_name,
+                context.equivalence().right_name
+            ),
+            None => "package invariant".to_string(),
+        }
     }
 }
 
@@ -186,7 +210,7 @@ impl SmtParser<SmtExpr, Error> for SmtRewrite<'_> {
         };
 
         self.handle_definefun(
-            &format!("game-invariant!{}!", self.game.unwrap().name()),
+            &names::game_invariant_fn_name(self.game.unwrap().name()),
             vec![(
                 SmtExpr::Atom("game".to_string()),
                 SmtExpr::Atom(gamestate_sort),
@@ -224,10 +248,9 @@ impl SmtParser<SmtExpr, Error> for SmtRewrite<'_> {
         };
 
         self.handle_definefun(
-            &format!(
-                "package-invariant!{}-{}!",
+            &names::package_invariant_fn_name(
                 self.game.unwrap().name(),
-                self.package.unwrap().name()
+                self.package.unwrap().name(),
             ),
             vec![(
                 SmtExpr::Atom("game".to_string()),
@@ -245,15 +268,14 @@ impl SmtParser<SmtExpr, Error> for SmtRewrite<'_> {
         args: Vec<SmtExpr>,
         body: SmtExpr,
     ) -> Result<SmtExpr> {
-        let left_game_inst = self
-            .context
+        let context = self.context("define-state-relation")?;
+        let left_game_inst = context
             .theorem()
-            .find_game_instance(&self.context.equivalence().left_name)
+            .find_game_instance(&context.equivalence().left_name)
             .unwrap();
-        let right_game_inst = self
-            .context
+        let right_game_inst = context
             .theorem()
-            .find_game_instance(&self.context.equivalence().right_name)
+            .find_game_instance(&context.equivalence().right_name)
             .unwrap();
         let left_game_state_pattern = patterns::GameStatePattern {
             game_name: left_game_inst.game_name(),
@@ -333,15 +355,14 @@ impl SmtParser<SmtExpr, Error> for SmtRewrite<'_> {
         args: Vec<SmtExpr>,
         body: SmtExpr,
     ) -> Result<SmtExpr> {
-        let left_game_inst = self
-            .context
+        let context = self.context("define-lemma")?;
+        let left_game_inst = context
             .theorem()
-            .find_game_instance(&self.context.equivalence().left_name)
+            .find_game_instance(&context.equivalence().left_name)
             .unwrap();
-        let right_game_inst = self
-            .context
+        let right_game_inst = context
             .theorem()
-            .find_game_instance(&self.context.equivalence().right_name)
+            .find_game_instance(&context.equivalence().right_name)
             .unwrap();
         let left_game_state_pattern = patterns::GameStatePattern {
             game_name: left_game_inst.game_name(),
@@ -533,6 +554,18 @@ pub fn rewrite_package(
     content: &str,
 ) -> Result<Vec<SmtExpr>> {
     let mut rewriter: SmtRewrite = SmtRewrite::new_with_package(context, game, package);
+    rewriter.parse_sexps(content)?;
+    Ok(rewriter.content)
+}
+
+/// Rewrites a package invariant file outside of an equivalence, i.e. for the synthetic game the
+/// package invariant is proved against.
+pub fn rewrite_standalone_package(
+    game: &GameInstance,
+    package: &PackageInstance,
+    content: &str,
+) -> Result<Vec<SmtExpr>> {
+    let mut rewriter: SmtRewrite = SmtRewrite::new_standalone_package(game, package);
     rewriter.parse_sexps(content)?;
     Ok(rewriter.content)
 }

--- a/src/gamehops/equivalence/verify_fn.rs
+++ b/src/gamehops/equivalence/verify_fn.rs
@@ -108,7 +108,7 @@ impl<'a, Backend: SmtSolverBackend + Sync, Proj: Project + Sync>
         );
         smt.push(SmtExpr::Comment("\n".to_string()));
         smt.push(SmtExpr::Comment("theorem param funcs:\n".to_string()));
-        smt.extend(&mut self.eqctx.emit_theorem_paramfuncs());
+        smt.extend(self.eqctx.emit_theorem_paramfuncs());
         log::debug!(
             "emitting game definitions for {}-{}",
             eq.left_name,
@@ -116,7 +116,7 @@ impl<'a, Backend: SmtSolverBackend + Sync, Proj: Project + Sync>
         );
         smt.push(SmtExpr::Comment("\n".to_string()));
         smt.push(SmtExpr::Comment("game definitions:\n".to_string()));
-        smt.extend(&mut self.eqctx.emit_game_definitions());
+        smt.extend(self.eqctx.emit_game_definitions());
 
         log::debug!(
             "emitting const declarations for {}-{}",
@@ -172,13 +172,11 @@ impl<'a, Backend: SmtSolverBackend + Sync, Proj: Project + Sync>
         Ok(())
     }
 
-    fn generate_game_or_package_invariant_start_asserts(&self) -> Vec<(String, SmtExpr)> {
-        self.generate_game_or_package_invariant_claims()
+    fn generate_game_invariant_start_asserts(&self) -> Vec<(String, SmtExpr)> {
+        self.generate_game_invariant_claims()
             .iter()
             .map(|claim| {
-                let smt = self
-                    .eqctx
-                    .emit_game_or_package_invariant_start_assert(claim);
+                let smt = self.eqctx.emit_game_invariant_start_assert(claim);
                 (claim.name().to_string(), smt)
             })
             .collect()
@@ -204,7 +202,7 @@ impl<'a, Backend: SmtSolverBackend + Sync, Proj: Project + Sync>
             "invariant".to_string(),
             self.eqctx.emit_invariant_start_assert(),
         )];
-        checks.append(&mut self.generate_game_or_package_invariant_start_asserts());
+        checks.append(&mut self.generate_game_invariant_start_asserts());
 
         ui.lock().unwrap().start_claim_group(
             &self.eqctx.theorem().name,
@@ -238,33 +236,6 @@ impl<'a, Backend: SmtSolverBackend + Sync, Proj: Project + Sync>
         result
     }
 
-    fn generate_package_invariant_claims(
-        &self,
-        gctx: GameInstanceContext<'a>,
-        claim_type: ClaimType,
-    ) -> Vec<Claim> {
-        gctx.game()
-            .pkgs
-            .iter()
-            .filter_map(|pkg| {
-                if pkg.pkg.invariants.is_empty() {
-                    None
-                } else {
-                    Some(Claim {
-                        admitted: false,
-                        dependencies: vec!["no-abort".to_string()],
-                        ty: claim_type,
-                        name: format!(
-                            "package-invariant!{}-{}!",
-                            gctx.game_inst_name(),
-                            pkg.name()
-                        ),
-                    })
-                }
-            })
-            .collect()
-    }
-
     fn generate_game_invariant_claim_if_exists(
         &self,
         gctx: GameInstanceContext<'a>,
@@ -275,23 +246,15 @@ impl<'a, Backend: SmtSolverBackend + Sync, Proj: Project + Sync>
                 admitted: false,
                 dependencies: vec!["no-abort".to_string()],
                 ty: claim_type,
-                name: format!("game-invariant!{}!", gctx.game_inst_name(),),
+                name: crate::writers::smt::names::game_invariant_fn_name(gctx.game_inst_name()),
             })
         } else {
             None
         }
     }
 
-    fn generate_game_or_package_invariant_claims(&self) -> Vec<Claim> {
+    fn generate_game_invariant_claims(&self) -> Vec<Claim> {
         let mut claims = vec![];
-        claims.extend(self.generate_package_invariant_claims(
-            self.eqctx.left_game_inst_ctx(),
-            ClaimType::LeftPackageInvariant,
-        ));
-        claims.extend(self.generate_package_invariant_claims(
-            self.eqctx.right_game_inst_ctx(),
-            ClaimType::RightPackageInvariant,
-        ));
 
         if let Some(claim) = self.generate_game_invariant_claim_if_exists(
             self.eqctx.left_game_inst_ctx(),
@@ -323,7 +286,7 @@ impl<'a, Backend: SmtSolverBackend + Sync, Proj: Project + Sync>
             .equivalence()
             .proof_tree_by_oracle_name(oracle.name());
 
-        claims.append(&mut self.generate_game_or_package_invariant_claims());
+        claims.append(&mut self.generate_game_invariant_claims());
 
         let claim_group = ClaimGroup::Oracle {
             oracle_name: oracle.name().to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod format;
 pub mod gamehops;
 pub mod identifier;
 pub mod package;
+pub mod package_invariant;
 pub mod packageinstance;
 //pub mod split;
 pub mod statement;

--- a/src/package_invariant/context.rs
+++ b/src/package_invariant/context.rs
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The SMT context for proving the invariant of a single package.
+//!
+//! This is the single-game counterpart of
+//! [`EquivalenceContext`](crate::writers::smt::contexts::EquivalenceContext): it emits the
+//! declarations of one game (the synthetic game from [`super::virtualgame`]) and the two kinds of
+//! claims a package invariant consists of.
+
+use std::collections::HashSet;
+
+use crate::{
+    gamehops::equivalence::smtrewrite,
+    package::{Package, PackageInstance},
+    project::Project,
+    theorem::{GameInstance, Theorem},
+    transforms::{samplify::SampleInfo, theorem_transforms},
+    types::Type,
+    writers::smt::{
+        contexts::{game_defs, GameInstanceContext, GenericOracleContext},
+        declare::declare_const,
+        exprs::{SmtAnd, SmtAssert, SmtExpr, SmtImplies, SmtNot},
+        names,
+        patterns::{
+            self,
+            functions::FunctionPattern,
+            oracle_args::{
+                GameStateOracleArgPattern, GameStateOracleArgVariant, OracleArgPattern,
+                UnitOracleArgPattern,
+            },
+            theorem_constants::ConstantPattern,
+            ReturnIsAbortConst,
+        },
+    },
+};
+
+use super::{
+    error::{Error, Result},
+    VirtualGame,
+};
+
+/// Everything needed to emit the SMT for the invariant of one package.
+pub(crate) struct PackageInvariantContext<'a> {
+    pkg: &'a Package,
+    theorem: Theorem<'a>,
+    game_inst_name: String,
+    pkg_inst_name: String,
+    types: HashSet<Type>,
+    sample_info: SampleInfo,
+    /// the rewritten contents of the package's invariant files
+    invariants: Vec<SmtExpr>,
+}
+
+impl<'a> PackageInvariantContext<'a> {
+    /// Builds the synthetic game for `pkg`, runs it through the usual transformation pipeline and
+    /// reads the package's invariant files.
+    pub(crate) fn new(pkg: &'a Package, project: &impl Project) -> Result<Self> {
+        if pkg.invariants.is_empty() {
+            return Err(Error::NoInvariant {
+                pkg_name: pkg.name.clone(),
+            });
+        }
+
+        let virtual_game = VirtualGame::new(pkg);
+        let game_inst_name = virtual_game.game_inst_name().to_string();
+        let pkg_inst_name = virtual_game.pkg_inst_name().to_string();
+
+        let (game_inst, (_, (types, sample_info))) =
+            theorem_transforms::transform_game_inst(virtual_game.game_inst())
+                .expect("transforming the synthetic package invariant game failed unexpectedly");
+
+        let theorem = virtual_game.theorem().with_new_instances(vec![game_inst]);
+
+        let mut this = Self {
+            pkg,
+            theorem,
+            game_inst_name,
+            pkg_inst_name,
+            types,
+            sample_info,
+            invariants: Vec::new(),
+        };
+
+        this.load_invariants(project)?;
+
+        Ok(this)
+    }
+
+    fn load_invariants(&mut self, project: &impl Project) -> Result<()> {
+        let mut out = Vec::new();
+
+        for file_name in &self.pkg.invariants {
+            let file_contents =
+                project
+                    .read_input_file(file_name)
+                    .map_err(|err| Error::InvariantFileRead {
+                        invariant_file_name: file_name.clone(),
+                        err,
+                    })?;
+
+            out.append(
+                &mut smtrewrite::rewrite_standalone_package(
+                    self.game_inst(),
+                    self.pkg_inst(),
+                    &file_contents,
+                )
+                .map_err(Box::new)?,
+            );
+        }
+
+        self.invariants = out;
+        Ok(())
+    }
+
+    pub(crate) fn pkg_name(&self) -> &'a str {
+        &self.pkg.name
+    }
+
+    fn game_inst(&self) -> &GameInstance {
+        &self.theorem.instances[0]
+    }
+
+    fn game_inst_ctx(&self) -> GameInstanceContext<'_> {
+        GameInstanceContext::new(self.game_inst())
+    }
+
+    fn pkg_inst(&self) -> &PackageInstance {
+        self.game_inst()
+            .game()
+            .pkgs
+            .iter()
+            .find(|pkg_inst| pkg_inst.name == self.pkg_inst_name)
+            .expect("the package under scrutiny is always part of the synthetic game")
+    }
+
+    /// The name of the SMT function the package invariant was rewritten into.
+    fn invariant_fn_name(&self) -> String {
+        names::package_invariant_fn_name(&self.game_inst_name, &self.pkg_inst_name)
+    }
+
+    /// The names of the oracles the package exposes, in declaration order.
+    pub(crate) fn oracle_names(&self) -> Vec<String> {
+        self.pkg
+            .oracles
+            .iter()
+            .map(|odef| odef.sig.name.clone())
+            .collect()
+    }
+}
+
+// emitting SMT
+impl PackageInvariantContext<'_> {
+    pub(crate) fn emit_base_declarations(&self) -> Vec<SmtExpr> {
+        let mut types: Vec<Type> = self
+            .types
+            .union(&game_defs::theorem_const_bits_types(&self.theorem))
+            .cloned()
+            .collect();
+        types.sort();
+
+        game_defs::emit_base_declarations(&types)
+    }
+
+    pub(crate) fn emit_theorem_paramfuncs(&self) -> Vec<SmtExpr> {
+        game_defs::emit_theorem_paramfuncs(&self.theorem)
+    }
+
+    pub(crate) fn emit_game_definitions(&self) -> Vec<SmtExpr> {
+        game_defs::emit_game_definitions(
+            &self.theorem,
+            &[(self.game_inst_ctx(), &self.sample_info)],
+        )
+    }
+
+    /// The definition of the package invariant itself.
+    pub(crate) fn emit_invariant(&self) -> Vec<SmtExpr> {
+        self.invariants.clone()
+    }
+
+    /// Declares the constants the oracle claims talk about: the old game state, the game
+    /// constants, the oracle arguments, the oracle return values and the randomness.
+    pub(crate) fn emit_constant_declarations(&self) -> Vec<SmtExpr> {
+        let gctx = self.game_inst_ctx();
+        let game_inst = self.game_inst();
+        let game_inst_name = &self.game_inst_name;
+        let game_name = gctx.game_name();
+
+        let mut out = Vec::new();
+
+        // the old game state, i.e. the arbitrary state we assume the invariant to hold in
+        let game_state = gctx.oracle_arg_game_state_pattern();
+        out.push(game_state.declare_old(game_inst_name));
+
+        // the theorem constants are arbitrary: this is what makes the proof hold for arbitrary
+        // package constants. The game constants are derived from them.
+        let theorem_consts = patterns::oracle_args::TheoremConstsPattern {
+            theorem_name: &self.theorem.name,
+        };
+        let game_consts = patterns::oracle_args::GameConstsPattern { game_name };
+
+        // the interface requires us to pass in a game instance name, but for the theorem constants
+        // that gets ignored.
+        let ignored_game_inst_name = "<ignored>";
+        out.push(theorem_consts.unit_declare(ignored_game_inst_name));
+
+        let const_mapping = patterns::const_mapping::GameConstMappingFunction {
+            theorem_name: &self.theorem.name,
+            game_name,
+            game_inst_name,
+        };
+        let const_mapping_call = const_mapping
+            .call(&[theorem_consts
+                .unit_global_const_name(ignored_game_inst_name)
+                .into()])
+            .unwrap();
+
+        out.push(
+            game_consts
+                .unit_define(game_inst_name, const_mapping_call)
+                .into(),
+        );
+
+        // the arguments of every oracle the package exposes
+        for export in &game_inst.game().exports {
+            let mut octx = gctx
+                .exported_oracle_ctx_by_name(export.name())
+                .expect("every export of the synthetic game points at an oracle");
+            octx.set_renamed(export.alias());
+
+            for (arg_name, arg_type) in &export.sig().args {
+                out.push(declare_const(
+                    octx.smt_arg_name(arg_name),
+                    arg_type.clone().into(),
+                ));
+            }
+        }
+
+        for (declare, constrain) in game_defs::build_returns(game_inst) {
+            out.push(declare);
+            out.push(constrain);
+        }
+
+        for (decl_ctr, constrain_ctr, _zero_ctr, decl_val, constrain_val) in
+            game_defs::build_rands(&self.sample_info, game_inst)
+        {
+            out.push(decl_ctr);
+            out.push(constrain_ctr);
+            out.push(decl_val);
+            out.push(constrain_val);
+        }
+
+        out.push(game_defs::define_randctr_function(
+            game_inst,
+            &self.sample_info,
+        ));
+
+        out
+    }
+
+    /// Declares the initial game state and fixes every state variable to the default value of its
+    /// type.
+    pub(crate) fn emit_initial_state_values(&self) -> Vec<SmtExpr> {
+        game_defs::emit_game_initial_state_values(self.game_inst_ctx())
+    }
+
+    /// `(assert (not (invariant <initial state>)))`
+    pub(crate) fn emit_invariant_start_assert(&self) -> SmtExpr {
+        let initial_state = self
+            .game_inst_ctx()
+            .oracle_arg_game_state_pattern()
+            .global_const_name(&self.game_inst_name, &GameStateOracleArgVariant::Initial);
+
+        SmtAssert(SmtNot((self.invariant_fn_name(), initial_state))).into()
+    }
+
+    /// `(assert (not (=> (and (invariant <old state>) (not <aborted>)) (invariant <new state>))))`
+    ///
+    /// We only require the invariant to be preserved by calls that return normally: when an oracle
+    /// aborts, the whole game aborts, so the state it leaves behind is never observed again.
+    pub(crate) fn emit_oracle_claim_assert(&self, oracle_name: &str) -> SmtExpr {
+        let gctx = self.game_inst_ctx();
+        let game_inst_name = &self.game_inst_name;
+
+        let octx = gctx
+            .exported_oracle_ctx_by_name(oracle_name)
+            .expect("the oracle is exported by the synthetic game");
+
+        let state = octx.oracle_arg_game_state_pattern();
+        let old_state = state.old_global_const_name(game_inst_name);
+        let new_state = state.new_global_const_name(game_inst_name, oracle_name.to_string());
+
+        let is_abort = ReturnIsAbortConst {
+            game_inst_name,
+            pkg_inst_name: &self.pkg_inst_name,
+            oracle_name,
+            ty: octx.oracle_return_type(),
+        };
+
+        let invariant = self.invariant_fn_name();
+
+        let precondition = SmtAnd(vec![
+            (invariant.clone(), old_state).into(),
+            SmtNot(is_abort.name()).into(),
+        ]);
+        let postcondition: SmtExpr = (invariant, new_state).into();
+
+        SmtAssert(SmtNot(SmtImplies(precondition, postcondition))).into()
+    }
+}

--- a/src/package_invariant/error.rs
+++ b/src/package_invariant/error.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use miette::Diagnostic;
+use std::path::PathBuf;
+use thiserror::Error;
+
+use crate::util::smtsolver::{Result as SmtSolverResponseResult, SmtSolverResponse};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Error, Diagnostic)]
+pub enum Error {
+    #[error("there is no package named {pkg_name} in this project")]
+    #[diagnostic(help("known packages: {}", .known_pkg_names.join(", ")))]
+    UnknownPackage {
+        pkg_name: String,
+        known_pkg_names: Vec<String>,
+    },
+
+    #[error("package {pkg_name} does not declare an invariant")]
+    #[diagnostic(help(
+        "add an `invariant: [ ./path/to/file.smt2 ]` entry to the package to give it one."
+    ))]
+    NoInvariant { pkg_name: String },
+
+    #[error("package {pkg_name} does not have an oracle named {oracle_name}")]
+    #[diagnostic(help("oracles of {pkg_name}: {}", .known_oracle_names.join(", ")))]
+    UnknownOracle {
+        pkg_name: String,
+        oracle_name: String,
+        known_oracle_names: Vec<String>,
+    },
+
+    #[error("error reading invariant file {invariant_file_name}: {err}")]
+    InvariantFileRead {
+        invariant_file_name: String,
+        err: std::io::Error,
+    },
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvariantRewrite(#[from] Box<crate::gamehops::equivalence::error::Error>),
+
+    #[error(transparent)]
+    ClaimFailed(#[from] ClaimFailedError),
+
+    #[error("failed to prove the invariant of package {pkg_name}")]
+    Parallel {
+        pkg_name: String,
+
+        #[related]
+        failed_claims: Vec<Error>,
+    },
+
+    #[error("SMT solver failed when verifying {claim_group_name} of package {pkg_name}")]
+    ProverProcess {
+        pkg_name: String,
+        claim_group_name: String,
+        #[related]
+        solver_errors: Vec<crate::util::smtsolver::Error>,
+    },
+}
+
+impl Error {
+    pub(crate) fn prover_process(
+        pkg_name: &str,
+        claim_group_name: &str,
+        err: crate::util::smtsolver::Error,
+    ) -> Self {
+        Self::ProverProcess {
+            pkg_name: pkg_name.to_string(),
+            claim_group_name: claim_group_name.to_string(),
+            solver_errors: vec![err],
+        }
+    }
+}
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("the invariant of package {pkg_name} could not be proved for {claim_group_name} (solver said {response})")]
+#[diagnostic(help("{}", format_modelfile(.modelfile)))]
+pub struct ClaimFailedError {
+    pub pkg_name: String,
+    pub claim_group_name: String,
+    pub response: SmtSolverResponse,
+    pub modelfile: SmtSolverResponseResult<PathBuf>,
+}
+
+fn format_modelfile(modelfile: &SmtSolverResponseResult<PathBuf>) -> String {
+    match modelfile {
+        Ok(path) => format!("the model is at {}", path.display()),
+        Err(err) => format!("could not get a model from the solver: {err}"),
+    }
+}

--- a/src/package_invariant/mod.rs
+++ b/src/package_invariant/mod.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Proving the invariants a package declares.
+//!
+//! A package invariant is a property of the state of a single package. It is used as an assumption
+//! when proving equivalences, so it needs to be established separately -- by induction over the
+//! oracle calls the package offers:
+//!
+//!  * *invariant start*: the invariant holds in the initial state of the package, and
+//!  * *one claim per oracle*: if the invariant holds before a call to that oracle, and the call
+//!    does not abort, then it holds afterwards.
+//!
+//! This is done once per package, for arbitrary package constants, against the synthetic game
+//! built in [`virtualgame`]. That implies the property we need in every game the package is used
+//! in: whatever an exported oracle of a game does, it can only touch the package's state by
+//! calling the package's own oracles.
+
+pub mod error;
+
+mod context;
+mod verify;
+mod virtualgame;
+
+pub(crate) use context::PackageInvariantContext;
+pub(crate) use verify::{PackageInvariantSmtDriver, UI_SECTION_NAME};
+pub(crate) use virtualgame::VirtualGame;

--- a/src/package_invariant/verify.rs
+++ b/src/package_invariant/verify.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::io::Write as _;
+use std::sync::{Arc, Mutex};
+
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+
+use crate::{
+    project::Project,
+    ui::TheoremUI,
+    util::smtsolver::{SmtSolver, SmtSolverBackend, SmtSolverResponse},
+    writers::smt::exprs::SmtExpr,
+};
+
+use super::{
+    context::PackageInvariantContext,
+    error::{ClaimFailedError, Error, Result},
+};
+
+/// The name the package invariant checks appear under in the UI, in place of a theorem name.
+pub(crate) const UI_SECTION_NAME: &str = "Package Invariants";
+
+/// The name of the claim group that checks the invariant holds in the initial state.
+pub(crate) const INVARIANT_START: &str = "invariant-start";
+
+/// One thing we prove about a package invariant.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ClaimGroup {
+    /// the invariant holds in the initial state of the package
+    InvariantStart,
+    /// the invariant is preserved by a call to this oracle
+    Oracle { oracle_name: String },
+}
+
+impl ClaimGroup {
+    fn ui_name(&self) -> &str {
+        match self {
+            Self::InvariantStart => INVARIANT_START,
+            Self::Oracle { oracle_name } => oracle_name,
+        }
+    }
+
+    fn file_system_name(&self) -> String {
+        match self {
+            Self::InvariantStart => "!invariant-start!".to_string(),
+            Self::Oracle { oracle_name } => oracle_name.clone(),
+        }
+    }
+}
+
+/// Proves the invariant of a single package against its synthetic game.
+pub(crate) struct PackageInvariantSmtDriver<
+    'a,
+    Backend: SmtSolverBackend + Sync,
+    Proj: Project + Sync,
+> {
+    ctx: &'a PackageInvariantContext<'a>,
+    project: &'a Proj,
+    backend: &'a Backend,
+    transcript: bool,
+    req_oracle: Option<&'a str>,
+    parallel: usize,
+    invariant_start_only: bool,
+}
+
+impl<'a, Backend: SmtSolverBackend + Sync, Proj: Project + Sync>
+    PackageInvariantSmtDriver<'a, Backend, Proj>
+{
+    pub(crate) fn new(
+        ctx: &'a PackageInvariantContext<'a>,
+        project: &'a Proj,
+        backend: &'a Backend,
+        transcript: bool,
+        req_oracle: Option<&'a str>,
+        parallel: usize,
+        invariant_start_only: bool,
+    ) -> Self {
+        Self {
+            ctx,
+            project,
+            backend,
+            transcript,
+            req_oracle,
+            parallel,
+            invariant_start_only,
+        }
+    }
+
+    /// Returns the claim groups to verify, honouring `--oracle` and `--invariant-start`.
+    fn claim_groups(&self) -> Result<Vec<ClaimGroup>> {
+        if self.invariant_start_only {
+            return Ok(vec![ClaimGroup::InvariantStart]);
+        }
+
+        let oracle_names = self.ctx.oracle_names();
+
+        if let Some(req_oracle) = self.req_oracle {
+            if !oracle_names.iter().any(|name| name == req_oracle) {
+                return Err(Error::UnknownOracle {
+                    pkg_name: self.ctx.pkg_name().to_string(),
+                    oracle_name: req_oracle.to_string(),
+                    known_oracle_names: oracle_names,
+                });
+            }
+
+            return Ok(vec![ClaimGroup::Oracle {
+                oracle_name: req_oracle.to_string(),
+            }]);
+        }
+
+        Ok(std::iter::once(ClaimGroup::InvariantStart)
+            .chain(
+                oracle_names
+                    .into_iter()
+                    .map(|oracle_name| ClaimGroup::Oracle { oracle_name }),
+            )
+            .collect())
+    }
+
+    pub(crate) fn verify<UI: TheoremUI + Send>(&self, ui: &mut UI) -> Result<()> {
+        let pkg_name = self.ctx.pkg_name();
+        let claim_groups = self.claim_groups()?;
+
+        log::info!("verify: package invariant of {pkg_name}");
+
+        // the declarations every claim needs
+        let mut base_smt = Vec::new();
+        base_smt.push(SmtExpr::Comment("base declarations:\n".to_string()));
+        base_smt.extend(self.ctx.emit_base_declarations());
+        base_smt.push(SmtExpr::Comment("theorem param funcs:\n".to_string()));
+        base_smt.extend(self.ctx.emit_theorem_paramfuncs());
+        base_smt.push(SmtExpr::Comment("game definitions:\n".to_string()));
+        base_smt.extend(self.ctx.emit_game_definitions());
+
+        let ui = Arc::new(Mutex::new(ui));
+        ui.lock().unwrap().proofstep_set_claim_groups_count(
+            UI_SECTION_NAME,
+            pkg_name,
+            claim_groups.len().try_into().unwrap(),
+        );
+
+        let results: Vec<Result<()>> = rayon::ThreadPoolBuilder::new()
+            .num_threads(self.parallel + 1) // one thread is reserved for the "main" method
+            .build()
+            .unwrap()
+            .install(|| {
+                claim_groups
+                    .par_iter()
+                    .map(|claim_group| self.verify_claim_group(ui.clone(), &base_smt, claim_group))
+                    .collect()
+            });
+
+        let failed_claims: Vec<_> = results.into_iter().filter_map(Result::err).collect();
+        if !failed_claims.is_empty() {
+            return Err(Error::Parallel {
+                pkg_name: pkg_name.to_string(),
+                failed_claims,
+            });
+        }
+
+        Ok(())
+    }
+
+    fn verify_claim_group<UI: TheoremUI + Send>(
+        &self,
+        ui: Arc<Mutex<&mut UI>>,
+        base_smt: &[SmtExpr],
+        claim_group: &ClaimGroup,
+    ) -> Result<()> {
+        let pkg_name = self.ctx.pkg_name();
+
+        // at the moment every group holds exactly one claim. Once packages can declare several
+        // named invariants, this is where the claims of a group get enumerated.
+        ui.lock()
+            .unwrap()
+            .start_claim_group(UI_SECTION_NAME, pkg_name, claim_group.ui_name(), 1);
+        ui.lock().unwrap().start_claim(
+            UI_SECTION_NAME,
+            pkg_name,
+            claim_group.ui_name(),
+            "package-invariant",
+        );
+
+        let mut smt = base_smt.to_owned();
+        smt.extend(self.ctx.emit_invariant());
+
+        match claim_group {
+            ClaimGroup::InvariantStart => {
+                smt.extend(self.ctx.emit_initial_state_values());
+                smt.push(self.ctx.emit_invariant_start_assert());
+            }
+            ClaimGroup::Oracle { oracle_name } => {
+                smt.extend(self.ctx.emit_constant_declarations());
+                smt.push(self.ctx.emit_oracle_claim_assert(oracle_name));
+            }
+        }
+
+        let result = self.verify_with_solver(smt, claim_group);
+
+        ui.lock().unwrap().finish_claim(
+            UI_SECTION_NAME,
+            pkg_name,
+            claim_group.ui_name(),
+            "package-invariant",
+        );
+        ui.lock()
+            .unwrap()
+            .finish_claim_group(UI_SECTION_NAME, pkg_name, claim_group.ui_name());
+
+        result
+    }
+
+    fn verify_with_solver(&self, smt: Vec<SmtExpr>, claim_group: &ClaimGroup) -> Result<()> {
+        let pkg_name = self.ctx.pkg_name();
+        let claim_group_name = claim_group.ui_name();
+
+        let mut solver = if self.transcript {
+            let transcript_file = self
+                .project
+                .get_package_invariant_smt_file(pkg_name, &claim_group.file_system_name())
+                .unwrap();
+
+            self.backend.new_smtsolver_with_transcript(transcript_file)
+        } else {
+            self.backend.new_smtsolver()
+        }
+        .map_err(|err| Error::prover_process(pkg_name, claim_group_name, err))?;
+
+        for entry in smt {
+            solver
+                .write_smt(entry)
+                .map_err(|err| Error::prover_process(pkg_name, claim_group_name, err))?;
+        }
+
+        match solver
+            .check_sat()
+            .map_err(|err| Error::prover_process(pkg_name, claim_group_name, err))?
+        {
+            SmtSolverResponse::Unsat => Ok(()),
+            response => {
+                let modelfile = solver.get_model().map(|(modelstring, _model)| {
+                    let mut modelfile =
+                        tempfile::Builder::new().suffix(".smt2").tempfile().unwrap();
+                    modelfile.write_all(modelstring.as_bytes()).unwrap();
+                    let (_, fname) = modelfile.keep().unwrap();
+                    fname
+                });
+                solver.close();
+
+                Err(ClaimFailedError {
+                    pkg_name: pkg_name.to_string(),
+                    claim_group_name: claim_group_name.to_string(),
+                    response,
+                    modelfile,
+                }
+                .into())
+            }
+        }
+    }
+}

--- a/src/package_invariant/virtualgame.rs
+++ b/src/package_invariant/virtualgame.rs
@@ -1,0 +1,686 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Builds the synthetic game that a package invariant is proved against.
+//!
+//! A package invariant is a property of a single package `P`, and it should be proved once, for
+//! arbitrary package constants, instead of once per instance of `P` in every game of every
+//! theorem. To do that we need to give `P` an environment: `P` may import oracles, and those
+//! imported oracles may be stateful and may share state with each other.
+//!
+//! We model that environment by a *virtual package* `V`:
+//!
+//!  * `V` exposes exactly the oracles that `P` imports, so `P` composed with `V` is a closed game.
+//!  * `V` has a single state variable of type `Bits(*)`, which stands for an arbitrary encoding of
+//!    whatever state the real environment keeps. A single variable is enough (and necessary):
+//!    imported oracles may share state, either because they come from the same package or because
+//!    the packages they come from call a common package.
+//!  * Each oracle of `V` is implemented by an uninterpreted function of the same name, taking the
+//!    environment state and the oracle arguments, and returning
+//!    `Maybe((Bits(*), <return type>))`. `None` means the imported oracle aborts; otherwise the
+//!    pair is unwrapped into the new environment state and the value that is returned.
+//!
+//! Because the function is uninterpreted and the state is an arbitrary bit string, every behaviour
+//! a real environment could exhibit -- including returning different values for the same arguments
+//! -- is covered.
+//!
+//! The result is a normal [`Theorem`] with a single [`GameInstance`], so the existing translation
+//! of oracle bodies to SMT applies unchanged.
+
+use miette::SourceSpan;
+
+use crate::{
+    expressions::{Expression, ExpressionKind},
+    identifier::{
+        game_ident::{GameConstIdentifier, GameIdentifier},
+        pkg_ident::{
+            PackageConstIdentifier, PackageIdentifier, PackageLocalIdentifier,
+            PackageStateIdentifier,
+        },
+        theorem_ident::TheoremConstIdentifier,
+        Identifier,
+    },
+    package::{Composition, Edge, Export, OracleDef, OracleSig, Package, PackageInstance},
+    statement::{Assignment, AssignmentRhs, CodeBlock, Pattern, Statement},
+    theorem::{GameInstance, Theorem},
+    types::{CountSpec, Type, TypeKind},
+};
+
+/// The name of the single state variable of the virtual package.
+const VIRTUAL_STATE_VAR: &str = "virtual$state";
+
+/// The name of the local variable holding the (still wrapped) result of the virtual function.
+const VIRTUAL_RESULT_VAR: &str = "virtual$result";
+
+/// The name of the local variable holding the value the virtual oracle returns.
+const VIRTUAL_VALUE_VAR: &str = "virtual$value";
+
+/// A synthetic theorem that consists of a single game: the package under scrutiny, composed with
+/// the virtual package modelling the oracles it imports.
+pub(crate) struct VirtualGame<'a> {
+    theorem: Theorem<'a>,
+    game_inst_name: String,
+    pkg_inst_name: String,
+}
+
+impl<'a> VirtualGame<'a> {
+    /// Builds the synthetic theorem for `pkg`.
+    pub(crate) fn new(pkg: &Package) -> Self {
+        let pkg_name = pkg.name.clone();
+        let imports = sorted_imports(pkg);
+        let theorem_name = format!("{pkg_name}$Invariant");
+        let game_name = theorem_name.clone();
+        let game_inst_name = theorem_name.clone();
+        let pkg_inst_name = pkg_name.clone();
+        let virtual_pkg_name = format!("{pkg_name}$Env");
+        let virtual_pkg_inst_name = virtual_pkg_name.clone();
+
+        // ---- the constants of the synthetic game ------------------------------------------
+        //
+        // The game has one constant per package parameter of `P` (so the invariant is proved for
+        // arbitrary package constants) plus one constant per imported oracle, holding the
+        // uninterpreted function that implements it.
+        let mut game_consts: Vec<(String, Type)> = pkg
+            .params
+            .iter()
+            .map(|(name, ty, _)| {
+                (
+                    name.clone(),
+                    lift_type(ty, &pkg_name, Level::Game(&game_name)),
+                )
+            })
+            .collect();
+
+        // an imported oracle and a package parameter can never share a name -- they live in the
+        // same scope -- so we can name the constant holding the uninterpreted function after the
+        // oracle it implements.
+        for sig in &imports {
+            game_consts.push((
+                sig.name.clone(),
+                virtual_fn_type(&lift_oracle_sig(sig, &pkg_name, Level::Game(&game_name))),
+            ));
+        }
+        game_consts.sort();
+
+        // ---- the virtual package ----------------------------------------------------------
+        let virtual_pkg = build_virtual_package(pkg, &virtual_pkg_name, &imports);
+
+        // ---- instantiate both packages into the game --------------------------------------
+        let pkg_inst = PackageInstance::new(
+            &pkg_inst_name,
+            &game_name,
+            pkg,
+            game_const_assignments(&pkg.params, &pkg_name, &game_name, &game_consts),
+            vec![],
+        );
+        let virtual_pkg_inst = PackageInstance::new(
+            &virtual_pkg_inst_name,
+            &game_name,
+            &virtual_pkg,
+            game_const_assignments(
+                &virtual_pkg.params,
+                &virtual_pkg_name,
+                &game_name,
+                &game_consts,
+            ),
+            vec![],
+        );
+
+        const PKG_OFFS: usize = 0;
+        const VIRTUAL_OFFS: usize = 1;
+
+        // wire every oracle `P` imports up with the virtual package
+        let edges = virtual_pkg_inst
+            .pkg
+            .oracles
+            .iter()
+            .map(|odef| {
+                let sig = virtual_pkg_inst.instantiate_oracle_signature(odef.sig.clone());
+                Edge::new(PKG_OFFS, VIRTUAL_OFFS, sig, None)
+            })
+            .collect();
+
+        // and export every oracle `P` offers, so we can check the invariant for each of them
+        let exports = pkg_inst
+            .pkg
+            .oracles
+            .iter()
+            .map(|odef| {
+                let sig = pkg_inst.instantiate_oracle_signature(odef.sig.clone());
+                Export::new(PKG_OFFS, sig, None)
+            })
+            .collect();
+
+        let game = Composition {
+            pkgs: vec![pkg_inst, virtual_pkg_inst],
+            edges,
+            exports,
+            name: game_name.clone(),
+            consts: game_consts.clone(),
+            invariants: vec![],
+        };
+
+        // ---- lift the game constants to theorem constants ---------------------------------
+        let theorem_consts: Vec<(String, Type)> = game_consts
+            .iter()
+            .map(|(name, ty)| {
+                (
+                    name.clone(),
+                    lift_type(ty, &game_name, Level::Theorem(&theorem_name)),
+                )
+            })
+            .collect();
+
+        let game_inst_consts: Vec<(GameConstIdentifier, Expression)> = game_consts
+            .iter()
+            .zip(&theorem_consts)
+            .map(|((name, game_ty), (_, theorem_ty))| {
+                let game_const = GameConstIdentifier {
+                    game_name: game_name.clone(),
+                    name: name.clone(),
+                    ty: game_ty.clone(),
+                    game_inst_name: None,
+                    theorem_name: None,
+                    inst_info: None,
+                    assigned_value: None,
+                };
+
+                let theorem_const = TheoremConstIdentifier {
+                    theorem_name: theorem_name.clone(),
+                    name: name.clone(),
+                    ty: theorem_ty.clone(),
+                    inst_info: None,
+                };
+
+                (
+                    game_const,
+                    Expression::from(Identifier::from(theorem_const)),
+                )
+            })
+            .collect();
+
+        let game_inst = GameInstance::new(
+            game_inst_name.clone(),
+            theorem_name.clone(),
+            game,
+            vec![],
+            game_inst_consts,
+        );
+
+        let theorem = Theorem {
+            name: theorem_name,
+            consts: theorem_consts,
+            instances: vec![game_inst],
+            assumptions: vec![],
+            proofs: vec![],
+            game_hops: vec![],
+            pkgs: vec![pkg.clone(), virtual_pkg],
+        };
+
+        Self {
+            theorem,
+            game_inst_name,
+            pkg_inst_name,
+        }
+    }
+
+    pub(crate) fn theorem(&self) -> &Theorem<'a> {
+        &self.theorem
+    }
+
+    pub(crate) fn game_inst(&self) -> &GameInstance {
+        &self.theorem.instances[0]
+    }
+
+    pub(crate) fn game_inst_name(&self) -> &str {
+        &self.game_inst_name
+    }
+
+    /// The name the package under scrutiny is instantiated under in the synthetic game.
+    pub(crate) fn pkg_inst_name(&self) -> &str {
+        &self.pkg_inst_name
+    }
+}
+
+/// `(Bits(*), <args>) -> Maybe((Bits(*), <return type>))`
+fn virtual_fn_type(sig: &OracleSig) -> Type {
+    let mut arg_types = vec![environment_state_type()];
+    arg_types.extend(sig.args.iter().map(|(_, ty)| ty.clone()));
+
+    Type::fun(
+        arg_types,
+        Type::maybe(Type::tuple(vec![environment_state_type(), sig.ty.clone()])),
+    )
+}
+
+/// The type of the virtual package's state: an arbitrary bit string.
+fn environment_state_type() -> Type {
+    Type::bits(CountSpec::Any)
+}
+
+fn dummy_span() -> SourceSpan {
+    (0..0).into()
+}
+
+/// Builds the virtual package exposing the oracles `pkg` imports.
+fn build_virtual_package(pkg: &Package, virtual_pkg_name: &str, imports: &[OracleSig]) -> Package {
+    // The virtual package needs the parameters of `pkg`, because the signatures of the imported
+    // oracles may mention them (e.g. as the length in `Bits(n)`).
+    let mut params: Vec<(String, Type, SourceSpan)> = pkg
+        .params
+        .iter()
+        .map(|(name, ty, span)| {
+            (
+                name.clone(),
+                lift_type(ty, &pkg.name, Level::Package(virtual_pkg_name)),
+                *span,
+            )
+        })
+        .collect();
+
+    let mut oracles = Vec::with_capacity(imports.len());
+
+    for sig in imports {
+        let sig = lift_oracle_sig(sig, &pkg.name, Level::Package(virtual_pkg_name));
+        params.push((sig.name.clone(), virtual_fn_type(&sig), dummy_span()));
+        oracles.push(build_virtual_oracle(virtual_pkg_name, sig));
+    }
+
+    params.sort();
+
+    Package {
+        name: virtual_pkg_name.to_string(),
+        types: vec![],
+        params,
+        state: vec![(
+            VIRTUAL_STATE_VAR.to_string(),
+            environment_state_type(),
+            dummy_span(),
+        )],
+        oracles,
+        imports: vec![],
+        invariants: vec![],
+        file_name: pkg.file_name.clone(),
+        file_contents: pkg.file_contents.clone(),
+    }
+}
+
+/// Builds the body of one virtual oracle:
+///
+/// ```text
+/// oracle Foo(x: T) -> U {
+///     virtual$result <- Foo(virtual$state, x);        // Maybe((Bits(*), U))
+///     (virtual$state, virtual$value) <- Unwrap(virtual$result);
+///     return virtual$value;
+/// }
+/// ```
+///
+/// The `Unwrap` is what makes the oracle abort when the uninterpreted function returns `None`.
+fn build_virtual_oracle(virtual_pkg_name: &str, sig: OracleSig) -> OracleDef {
+    let oracle_name = sig.name.clone();
+    let returns_value = !matches!(sig.ty.kind(), TypeKind::Empty);
+
+    let state_ident = Identifier::from(PackageStateIdentifier {
+        pkg_name: virtual_pkg_name.to_string(),
+        name: VIRTUAL_STATE_VAR.to_string(),
+        ty: environment_state_type(),
+        pkg_inst_name: None,
+        game_name: None,
+        game_inst_name: None,
+        theorem_name: None,
+    });
+
+    let local = |name: &str, ty: Type| {
+        Identifier::PackageIdentifier(PackageIdentifier::Local(PackageLocalIdentifier {
+            pkg_name: virtual_pkg_name.to_string(),
+            oracle_name: oracle_name.clone(),
+            name: name.to_string(),
+            ty,
+            pkg_inst_name: None,
+            game_name: None,
+            game_inst_name: None,
+            theorem_name: None,
+        }))
+    };
+
+    let unwrapped_type = Type::tuple(vec![environment_state_type(), sig.ty.clone()]);
+    let result_ident = local(VIRTUAL_RESULT_VAR, Type::maybe(unwrapped_type));
+    let value_ident = local(VIRTUAL_VALUE_VAR, sig.ty.clone());
+
+    let fn_ident = Identifier::from(PackageConstIdentifier::new(
+        oracle_name.clone(),
+        virtual_pkg_name.to_string(),
+        virtual_fn_type(&sig),
+    ));
+
+    let mut call_args = vec![Expression::from(state_ident.clone())];
+    call_args.extend(sig.args.iter().map(|(name, ty)| {
+        Expression::from(Identifier::PackageIdentifier(PackageIdentifier::OracleArg(
+            crate::identifier::pkg_ident::PackageOracleArgIdentifier {
+                pkg_name: virtual_pkg_name.to_string(),
+                oracle_name: oracle_name.clone(),
+                name: name.clone(),
+                ty: ty.clone(),
+                pkg_inst_name: None,
+                game_name: None,
+                game_inst_name: None,
+                theorem_name: None,
+            },
+        )))
+    }));
+
+    let call = Expression::from_kind(ExpressionKind::FnCall(fn_ident, call_args));
+
+    let unwrap = Expression::from_kind(ExpressionKind::Unwrap(Box::new(Expression::from(
+        result_ident.clone(),
+    ))));
+
+    let code = CodeBlock(vec![
+        Statement::Assignment(
+            Assignment {
+                pattern: Pattern::Ident(result_ident),
+                rhs: AssignmentRhs::Expression(call),
+            },
+            dummy_span(),
+        ),
+        Statement::Assignment(
+            Assignment {
+                pattern: Pattern::Tuple(vec![state_ident, value_ident.clone()]),
+                rhs: AssignmentRhs::Expression(unwrap),
+            },
+            dummy_span(),
+        ),
+        Statement::Return(
+            returns_value.then(|| Expression::from(value_ident)),
+            dummy_span(),
+        ),
+    ]);
+
+    OracleDef {
+        sig,
+        code,
+        file_pos: dummy_span(),
+    }
+}
+
+/// Assigns each parameter of a package the game constant of the same name.
+fn game_const_assignments(
+    params: &[(String, Type, SourceSpan)],
+    pkg_name: &str,
+    game_name: &str,
+    game_consts: &[(String, Type)],
+) -> Vec<(PackageConstIdentifier, Expression)> {
+    let mut assignments: Vec<_> = params
+        .iter()
+        .map(|(name, _ty, _span)| {
+            let (_, game_ty) = game_consts
+                .iter()
+                .find(|(game_const_name, _)| game_const_name == name)
+                .unwrap_or_else(|| {
+                    panic!("no game constant for parameter `{name}' of package `{pkg_name}'")
+                });
+
+            let value = Expression::from(Identifier::GameIdentifier(GameIdentifier::Const(
+                GameConstIdentifier {
+                    game_name: game_name.to_string(),
+                    name: name.clone(),
+                    ty: game_ty.clone(),
+                    game_inst_name: None,
+                    theorem_name: None,
+                    inst_info: None,
+                    assigned_value: None,
+                },
+            )));
+
+            let ident = PackageConstIdentifier {
+                pkg_name: pkg_name.to_string(),
+                name: name.clone(),
+                ty: value.get_type(),
+                game_name: None,
+                game_assignment: None,
+                pkg_inst_name: None,
+                game_inst_name: None,
+                theorem_name: None,
+            };
+
+            (ident, value)
+        })
+        .collect();
+
+    assignments.sort();
+    assignments
+}
+
+/// The signatures of the oracles `pkg` imports, sorted by name.
+///
+/// The parser collects the imports in a hash map, so their order is not stable across runs. We
+/// need a stable order here, because it decides the order of the oracles of the virtual package,
+/// and with it the order of the SMT we emit.
+fn sorted_imports(pkg: &Package) -> Vec<OracleSig> {
+    let mut imports: Vec<OracleSig> = pkg.imports.iter().map(|(sig, _span)| sig.clone()).collect();
+    imports.sort_by(|left, right| left.name.cmp(&right.name));
+    imports
+}
+
+/// The three levels constants live at. A `Bits(n)` length is spelled with a different kind of
+/// identifier depending on which level the surrounding type belongs to.
+#[derive(Clone, Copy)]
+enum Level<'a> {
+    Package(&'a str),
+    Game(&'a str),
+    Theorem(&'a str),
+}
+
+/// Rewrites the `Bits(<length>)` lengths in `sig` from the level of `from` to `to`.
+fn lift_oracle_sig(sig: &OracleSig, from: &str, to: Level) -> OracleSig {
+    OracleSig {
+        name: sig.name.clone(),
+        args: sig
+            .args
+            .iter()
+            .map(|(name, ty)| (name.clone(), lift_type(ty, from, to)))
+            .collect(),
+        ty: lift_type(&sig.ty, from, to),
+    }
+}
+
+/// Rewrites the `Bits(<length>)` lengths of `ty` to refer to the constants of `to`.
+///
+/// Every level (package, game, theorem) refers to its constants with its own kind of identifier,
+/// and in the synthetic game we build here a constant is always assigned the constant of the same
+/// name at the next level. So lifting a type just means swapping the identifier, keeping the name.
+fn lift_type(ty: &Type, from: &str, to: Level) -> Type {
+    let lift_all =
+        |tys: &[Type]| -> Vec<Type> { tys.iter().map(|ty| lift_type(ty, from, to)).collect() };
+
+    match ty.kind() {
+        TypeKind::Bits(count_spec) => Type::bits(lift_count_spec(count_spec, from, to)),
+        TypeKind::Tuple(tys) => Type::tuple(lift_all(tys)),
+        TypeKind::Table(key, value) => {
+            Type::table(lift_type(key, from, to), lift_type(value, from, to))
+        }
+        TypeKind::Fn(arg_tys, ret_ty) => Type::fun(lift_all(arg_tys), lift_type(ret_ty, from, to)),
+        TypeKind::List(inner) => Type::list(lift_type(inner, from, to)),
+        TypeKind::Set(inner) => Type::set(lift_type(inner, from, to)),
+        TypeKind::Maybe(inner) => Type::maybe(lift_type(inner, from, to)),
+        _ => ty.clone(),
+    }
+}
+
+fn lift_count_spec(count_spec: &CountSpec, from: &str, to: Level) -> CountSpec {
+    let CountSpec::Identifier(ident) = count_spec else {
+        return count_spec.clone();
+    };
+
+    // only rewrite constants that belong to the level we are lifting away from
+    let name = match ident.as_ref() {
+        Identifier::PackageIdentifier(PackageIdentifier::Const(pkg_const))
+            if pkg_const.pkg_name == from =>
+        {
+            &pkg_const.name
+        }
+        Identifier::GameIdentifier(GameIdentifier::Const(game_const))
+            if game_const.game_name == from =>
+        {
+            &game_const.name
+        }
+        _ => return count_spec.clone(),
+    };
+
+    let lifted = match to {
+        Level::Package(pkg_name) => Identifier::from(PackageConstIdentifier::new(
+            name.clone(),
+            pkg_name.to_string(),
+            Type::integer(),
+        )),
+        Level::Game(game_name) => {
+            Identifier::GameIdentifier(GameIdentifier::Const(GameConstIdentifier {
+                game_name: game_name.to_string(),
+                name: name.clone(),
+                ty: Type::integer(),
+                game_inst_name: None,
+                theorem_name: None,
+                inst_info: None,
+                assigned_value: None,
+            }))
+        }
+        Level::Theorem(theorem_name) => Identifier::from(TheoremConstIdentifier {
+            theorem_name: theorem_name.to_string(),
+            name: name.clone(),
+            ty: Type::integer(),
+            inst_info: None,
+        }),
+    };
+
+    CountSpec::Identifier(Box::new(lifted))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::tests::packages;
+
+    const CTR: &str = r#"
+package Ctr {
+    params {
+        n: Integer,
+    }
+
+    state {
+        ctr: Integer,
+    }
+
+    import oracles {
+        Get(x: Integer) -> Bits(n),
+        Put(y: Bits(n)),
+    }
+
+    oracle Step(x: Integer) -> Bits(n) {
+        y <- invoke Get(x);
+        ctr <- (ctr + 1);
+        return y;
+    }
+
+    oracle Peek() -> Integer {
+        return ctr;
+    }
+}
+"#;
+
+    const NO_IMPORTS: &str = r#"
+package Closed {
+    params {
+        n: Integer,
+    }
+
+    state {
+        ctr: Integer,
+    }
+
+    oracle Peek() -> Integer {
+        return ctr;
+    }
+}
+"#;
+
+    #[test]
+    fn virtual_package_exposes_exactly_the_imported_oracles() {
+        let (_, pkg) = packages::parse(CTR.trim_start(), "Ctr.pkg.ssp");
+        let virtual_game = VirtualGame::new(&pkg);
+        let game = virtual_game.game_inst().game();
+
+        assert_eq!(game.pkgs.len(), 2, "the package and its environment");
+
+        let env = &game.pkgs[1];
+        let env_oracle_names: Vec<&str> = env
+            .pkg
+            .oracles
+            .iter()
+            .map(|odef| odef.sig.name.as_str())
+            .collect();
+
+        assert_eq!(env_oracle_names, vec!["Get", "Put"]);
+        assert!(
+            env.pkg.imports.is_empty(),
+            "the environment is the rightmost package, it imports nothing"
+        );
+        assert_eq!(
+            env.pkg.state.len(),
+            1,
+            "the environment has a single state variable standing for an arbitrary encoding"
+        );
+    }
+
+    #[test]
+    fn every_import_is_wired_up_and_every_oracle_is_exported() {
+        let (_, pkg) = packages::parse(CTR.trim_start(), "Ctr.pkg.ssp");
+        let virtual_game = VirtualGame::new(&pkg);
+        let game = virtual_game.game_inst().game();
+
+        assert_eq!(game.edges.len(), pkg.imports.len());
+        assert!(
+            game.edges
+                .iter()
+                .all(|edge| edge.from() == 0 && edge.to() == 1),
+            "every import points from the package under scrutiny at the environment"
+        );
+
+        let exported: Vec<&str> = game.exports.iter().map(|export| export.name()).collect();
+        assert_eq!(exported, vec!["Step", "Peek"]);
+    }
+
+    #[test]
+    fn the_package_keeps_its_own_name_as_the_instance_name() {
+        let (_, pkg) = packages::parse(CTR.trim_start(), "Ctr.pkg.ssp");
+        let virtual_game = VirtualGame::new(&pkg);
+
+        assert_eq!(virtual_game.pkg_inst_name(), "Ctr");
+        assert_eq!(virtual_game.game_inst().game().pkgs[0].name, "Ctr");
+    }
+
+    #[test]
+    fn the_package_constants_become_theorem_constants() {
+        let (_, pkg) = packages::parse(CTR.trim_start(), "Ctr.pkg.ssp");
+        let virtual_game = VirtualGame::new(&pkg);
+
+        let const_names: Vec<&str> = virtual_game
+            .theorem()
+            .consts
+            .iter()
+            .map(|(name, _)| name.as_str())
+            .collect();
+
+        // `n` is the package parameter, `Get` and `Put` hold the uninterpreted functions
+        // implementing the imported oracles
+        assert_eq!(const_names, vec!["Get", "Put", "n"]);
+    }
+
+    #[test]
+    fn a_package_without_imports_gets_an_empty_environment() {
+        let (_, pkg) = packages::parse(NO_IMPORTS.trim_start(), "Closed.pkg.ssp");
+        let virtual_game = VirtualGame::new(&pkg);
+        let game = virtual_game.game_inst().game();
+
+        assert!(game.edges.is_empty());
+        assert!(game.pkgs[1].pkg.oracles.is_empty());
+    }
+}

--- a/src/project/error.rs
+++ b/src/project/error.rs
@@ -49,6 +49,9 @@ pub enum Error {
     EquivalenceError(#[from] crate::gamehops::equivalence::error::Error),
     #[diagnostic(transparent)]
     #[error(transparent)]
+    PackageInvariantError(#[from] crate::package_invariant::error::Error),
+    #[diagnostic(transparent)]
+    #[error(transparent)]
     ParsePackage(#[from] parser::package::ParsePackageError),
     #[diagnostic(transparent)]
     #[error(transparent)]

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -15,6 +15,9 @@ use crate::parser::ast::Identifier;
 use crate::{
     gamehops::{equivalence::EquivalenceSmtDriver, GameHop},
     package::{Composition, Package},
+    package_invariant::{
+        self, PackageInvariantContext, PackageInvariantSmtDriver, UI_SECTION_NAME,
+    },
     theorem::Theorem,
     transforms::{theorem_transforms::EquivalenceTransform, TheoremTransform, Transformation},
     util::smtsolver::SmtSolverBackend,
@@ -97,6 +100,153 @@ pub trait Project {
         Ok(())
     }
 
+    /// The names of the packages that declare an invariant, sorted.
+    fn packages_with_invariants(&self) -> Vec<&str> {
+        let mut names: Vec<&str> = self
+            .packages()
+            .filter(|name| {
+                self.get_package(name)
+                    .is_some_and(|pkg| !pkg.invariants.is_empty())
+            })
+            .collect();
+        names.sort();
+        names
+    }
+
+    /// The packages whose invariant needs to be proved for the requested part of the project.
+    ///
+    /// Package invariants are used as assumptions in equivalence proofs, so we only need those of
+    /// the packages that are instantiated in a game of an equivalence (or hybrid) game hop that we
+    /// are actually going to verify. When the whole project is proved, all package invariants are
+    /// checked.
+    fn required_package_invariants(
+        &self,
+        req_theorem: &Option<String>,
+        req_proofstep: Option<usize>,
+    ) -> Vec<&str> {
+        let all = self.packages_with_invariants();
+
+        let Some(req_theorem) = req_theorem else {
+            return all;
+        };
+
+        let Some(theorem) = self.get_theorem(req_theorem) else {
+            return vec![];
+        };
+
+        let mut needed: Vec<&str> = all
+            .into_iter()
+            .filter(|pkg_name| {
+                theorem
+                    .game_hops
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| req_proofstep.is_none_or(|req| *i == req))
+                    .filter_map(|(_, game_hop)| match game_hop {
+                        GameHop::Equivalence(eq) => Some(eq),
+                        GameHop::Hybrid(hybrid) => Some(hybrid.equivalence()),
+                        GameHop::Reduction(_) | GameHop::Conjecture(_) => None,
+                    })
+                    .flat_map(|eq| [eq.left_name(), eq.right_name()])
+                    .filter_map(|game_inst_name| theorem.find_game_instance(game_inst_name))
+                    .any(|game_inst| {
+                        game_inst
+                            .game()
+                            .pkgs
+                            .iter()
+                            .any(|pkg_inst| pkg_inst.pkg.name == *pkg_name)
+                    })
+            })
+            .collect();
+
+        needed.sort();
+        needed
+    }
+
+    /// Proves the invariants of the given packages, as one section of the UI.
+    fn prove_package_invariants<UI: TheoremUI + Send>(
+        &self,
+        ui: &mut UI,
+        backend: &(impl SmtSolverBackend + Sync),
+        transcript: bool,
+        parallel: usize,
+        pkg_names: &[&str],
+        req_oracle: &Option<String>,
+        invariant_start: bool,
+    ) -> Result<()>
+    where
+        Self: Sized + Sync,
+    {
+        if pkg_names.is_empty() {
+            return Ok(());
+        }
+
+        ui.start_theorem(UI_SECTION_NAME, pkg_names.len().try_into().unwrap());
+
+        for pkg_name in pkg_names {
+            let pkg = self.get_package(pkg_name).unwrap();
+
+            ui.start_proofstep(UI_SECTION_NAME, pkg_name);
+
+            let ctx = PackageInvariantContext::new(pkg, self)?;
+            let driver = PackageInvariantSmtDriver::new(
+                &ctx,
+                self,
+                backend,
+                transcript,
+                req_oracle.as_deref(),
+                parallel,
+                invariant_start,
+            );
+            driver.verify(ui)?;
+
+            ui.finish_proofstep(UI_SECTION_NAME, pkg_name);
+        }
+
+        ui.finish_theorem(UI_SECTION_NAME);
+
+        Ok(())
+    }
+
+    /// Proves the invariant of a single package, without proving anything else.
+    ///
+    /// This is what `domino prove --package <name>` does.
+    fn prove_package(
+        &self,
+        backend: &(impl SmtSolverBackend + Sync),
+        transcript: bool,
+        parallel: usize,
+        pkg_name: &str,
+        req_oracle: &Option<String>,
+        invariant_start: bool,
+    ) -> Result<()>
+    where
+        Self: Sized + Sync,
+    {
+        if self.get_package(pkg_name).is_none() {
+            let mut known_pkg_names: Vec<String> = self.packages().map(str::to_string).collect();
+            known_pkg_names.sort();
+
+            return Err(package_invariant::error::Error::UnknownPackage {
+                pkg_name: pkg_name.to_string(),
+                known_pkg_names,
+            }
+            .into());
+        }
+
+        let mut ui = IndicatifTheoremUI::new(1);
+
+        self.prove_package_invariants(
+            &mut ui,
+            backend,
+            transcript,
+            parallel,
+            &[pkg_name],
+            req_oracle,
+            invariant_start,
+        )
+    }
+
     // we might want to return a theorem trace here instead
     // we could then extract the theorem viewer output and other useful info trom the trace
     fn prove(
@@ -116,7 +266,35 @@ pub trait Project {
         let mut theorem_keys: Vec<_> = self.theorems().collect();
         theorem_keys.sort();
 
-        let mut ui = IndicatifTheoremUI::new(theorem_keys.len().try_into().unwrap());
+        // Package invariants are theorem-independent, so we prove them once, up front, for the
+        // packages the requested part of the project actually relies on. When the user asks for a
+        // specific oracle, we only look at the packages that have an oracle of that name.
+        let package_invariants: Vec<&str> = self
+            .required_package_invariants(req_theorem, req_proofstep)
+            .into_iter()
+            .filter(|pkg_name| match req_oracle {
+                Some(req_oracle) if !invariant_start => self
+                    .get_package(pkg_name)
+                    .unwrap()
+                    .oracles
+                    .iter()
+                    .any(|odef| &odef.sig.name == req_oracle),
+                _ => true,
+            })
+            .collect();
+
+        let num_sections = theorem_keys.len() + usize::from(!package_invariants.is_empty());
+        let mut ui = IndicatifTheoremUI::new(num_sections.try_into().unwrap());
+
+        self.prove_package_invariants(
+            &mut ui,
+            backend,
+            transcript,
+            parallel,
+            &package_invariants,
+            req_oracle,
+            invariant_start,
+        )?;
 
         for theorem_key in theorem_keys.into_iter() {
             let theorem = self.get_theorem(theorem_key).unwrap();
@@ -232,6 +410,28 @@ pub trait Project {
         }
 
         Ok(())
+    }
+
+    /// The transcript file for one claim group of a package invariant proof.
+    fn get_package_invariant_smt_file(
+        &self,
+        pkg_name: &str,
+        claim_group_name: &str,
+    ) -> Result<std::fs::File> {
+        let mut path = self.get_root_dir();
+
+        path.push("_build/code_pkg/");
+        path.push(pkg_name);
+        std::fs::create_dir_all(&path)?;
+
+        path.push(format!("{claim_group_name}.smt2"));
+        let f = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(path)?;
+
+        Ok(f)
     }
 
     fn get_smt_file(

--- a/src/theorem.rs
+++ b/src/theorem.rs
@@ -211,8 +211,6 @@ pub enum ClaimType {
     Lemma,
     Relation,
     Invariant,
-    LeftPackageInvariant,
-    RightPackageInvariant,
     LeftGameInvariant,
     RightGameInvariant,
 }

--- a/src/transforms/theorem_transforms.rs
+++ b/src/transforms/theorem_transforms.rs
@@ -30,7 +30,8 @@ impl super::TheoremTransform for EquivalenceTransform {
     }
 }
 
-fn transform_game_inst(
+/// Runs a single game instance through the transformation pipeline that the SMT writers expect.
+pub(crate) fn transform_game_inst(
     game_inst: &GameInstance,
 ) -> Result<
     (

--- a/src/writers/smt/contexts/equivalence.rs
+++ b/src/writers/smt/contexts/equivalence.rs
@@ -6,23 +6,16 @@ mod emit;
 
 use crate::{
     gamehops::equivalence::Equivalence,
-    identifier::{
-        theorem_ident::{TheoremConstIdentifier, TheoremIdentifier},
-        Identifier,
-    },
     package::OracleSig,
     theorem::Theorem,
     transforms::{
         samplify::SampleInfo, theorem_transforms::EquivalenceTransform, TheoremTransform,
     },
-    types::{CountSpec, Type, TypeKind},
+    types::Type,
     writers::smt::{
-        contexts,
+        contexts::{self, game_defs},
         exprs::SmtExpr,
-        patterns::{
-            relation::Relation, relations::equal_aborts, theorem_consts::TheoremConstsPattern,
-            GameStatePattern,
-        },
+        patterns::{relation::Relation, relations::equal_aborts, GameStatePattern},
     },
 };
 
@@ -157,12 +150,6 @@ impl<'a> EquivalenceContext<'a> {
         self.relation_pattern("same-output", oracle_name)
             .build_same_output()
     }
-
-    pub(crate) fn datastructure_theorem_consts_pattern(&'a self) -> TheoremConstsPattern<'a> {
-        let theorem_name = &self.theorem().name;
-
-        TheoremConstsPattern { theorem_name }
-    }
 }
 
 impl<'a> EquivalenceContext<'a> {
@@ -177,26 +164,7 @@ impl<'a> EquivalenceContext<'a> {
             .iter()
             .find(|(name, _aux)| name == self.equivalence().right_name())
             .unwrap();
-        let types_theorem: HashSet<Type> = self
-            .theorem()
-            .consts
-            .iter()
-            .filter_map(|(name, ty)| match ty.kind() {
-                TypeKind::Integer => {
-                    let id = TheoremConstIdentifier {
-                        theorem_name: self.theorem().name.clone(),
-                        name: name.clone(),
-                        ty: Type::integer(),
-                        inst_info: None,
-                    };
-
-                    Some(Type::bits(CountSpec::Identifier(Box::new(
-                        Identifier::TheoremIdentifier(TheoremIdentifier::Const(id)),
-                    ))))
-                }
-                _ => None,
-            })
-            .collect();
+        let types_theorem = game_defs::theorem_const_bits_types(self.theorem());
 
         let mut types: Vec<_> = types_left
             .union(types_right)

--- a/src/writers/smt/contexts/equivalence/emit.rs
+++ b/src/writers/smt/contexts/equivalence/emit.rs
@@ -1,30 +1,21 @@
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::{
-    hacks,
     identifier::Identifier,
-    theorem::{Claim, ClaimType, GameInstance, RandomnessType},
-    transforms::samplify::SampleInfo,
+    theorem::{Claim, ClaimType, RandomnessType},
     types::{CountSpec, Type, TypeKind},
     writers::smt::{
-        contexts::{EquivalenceContext, GameInstanceContext, GenericOracleContext},
+        contexts::{game_defs, EquivalenceContext, GameInstanceContext, GenericOracleContext},
         declare::declare_const,
         exprs::{SmtAnd, SmtAssert, SmtEq2, SmtExpr, SmtForall, SmtImplies, SmtIte, SmtNot},
-        patterns,
+        names, patterns,
         patterns::{
-            const_mapping::GameConstMappingFunction,
-            const_mapping::{define_game_const_mapping_fun, define_pkg_const_mapping_fun},
-            datastructures::DatastructurePattern,
-            declare_datatype,
-            functions::FunctionPattern,
-            oracle_args::GameStateOracleArgPattern,
-            oracle_args::OracleArgPattern,
-            oracle_args::UnitOracleArgPattern,
-            theorem_constants::ConstantPattern,
-            GameStateDeclareInfo, ReturnIsAbortConst, SmtDefineFun,
+            const_mapping::GameConstMappingFunction, functions::FunctionPattern,
+            oracle_args::GameStateOracleArgPattern, oracle_args::OracleArgPattern,
+            oracle_args::UnitOracleArgPattern, theorem_constants::ConstantPattern,
+            ReturnIsAbortConst, SmtDefineFun,
         },
         sorts::Sort,
-        writer::CompositionSmtWriter,
     },
 };
 
@@ -36,44 +27,12 @@ impl<'a> EquivalenceContext<'a> {
     pub(crate) fn emit_initial_state_values(&self) -> Vec<SmtExpr> {
         let mut out = Vec::new();
 
-        out.extend(self.emit_game_initial_state_values(self.left_game_inst_ctx()));
-        out.extend(self.emit_game_initial_state_values(self.right_game_inst_ctx()));
-
-        out
-    }
-
-    fn emit_game_initial_state_values(&self, gctx: GameInstanceContext<'a>) -> Vec<SmtExpr> {
-        let game_inst_name = gctx.game_inst_name();
-        let initial_state = gctx.oracle_arg_game_state_pattern().global_const_name(
-            game_inst_name,
-            &patterns::oracle_args::GameStateOracleArgVariant::Initial,
-        );
-
-        let mut out = Vec::new();
-        out.push(
-            gctx.oracle_arg_game_state_pattern()
-                .declare_initial(game_inst_name),
-        );
-
-        for pctx in gctx.pkg_inst_contexts() {
-            let pkg_state = gctx
-                .smt_access_gamestate_pkgstate(&initial_state, pctx.pkg_inst_name())
-                .unwrap();
-
-            for (field_name, field_ty, _) in &pctx.pkg().state {
-                let field = pctx
-                    .smt_access_pkgstate(pkg_state.clone(), field_name)
-                    .unwrap();
-
-                out.push(
-                    SmtAssert(SmtEq2 {
-                        lhs: field,
-                        rhs: SmtExpr::from(&field_ty.default_expression()),
-                    })
-                    .into(),
-                );
-            }
-        }
+        out.extend(game_defs::emit_game_initial_state_values(
+            self.left_game_inst_ctx(),
+        ));
+        out.extend(game_defs::emit_game_initial_state_values(
+            self.right_game_inst_ctx(),
+        ));
 
         out
     }
@@ -96,14 +55,10 @@ impl<'a> EquivalenceContext<'a> {
         .into()
     }
 
-    pub(crate) fn emit_game_or_package_invariant_start_assert(&self, claim: &Claim) -> SmtExpr {
+    pub(crate) fn emit_game_invariant_start_assert(&self, claim: &Claim) -> SmtExpr {
         let gctx = match claim.ty {
-            ClaimType::LeftGameInvariant | ClaimType::LeftPackageInvariant => {
-                self.left_game_inst_ctx()
-            }
-            ClaimType::RightGameInvariant | ClaimType::RightPackageInvariant => {
-                self.right_game_inst_ctx()
-            }
+            ClaimType::LeftGameInvariant => self.left_game_inst_ctx(),
+            ClaimType::RightGameInvariant => self.right_game_inst_ctx(),
             _ => unreachable!(),
         };
         let game_inst_name = gctx.game_inst_name();
@@ -257,8 +212,6 @@ impl<'a> EquivalenceContext<'a> {
                     ClaimType::Lemma => build_lemma_call.clone()(dep_name),
                     ClaimType::Relation => build_relation_call(dep_name),
                     ClaimType::Invariant
-                    | ClaimType::LeftPackageInvariant
-                    | ClaimType::RightPackageInvariant
                     | ClaimType::LeftGameInvariant
                     | ClaimType::RightGameInvariant => unreachable!(),
                 }
@@ -269,8 +222,6 @@ impl<'a> EquivalenceContext<'a> {
             ClaimType::Lemma => build_lemma_call.clone()(&claim.name),
             ClaimType::Relation => build_relation_call(&claim.name),
             ClaimType::Invariant => build_invariant_new_call(&claim.name),
-            ClaimType::LeftPackageInvariant => build_left_invariant_new_call(&claim.name),
-            ClaimType::RightPackageInvariant => build_right_invariant_new_call(&claim.name),
             ClaimType::LeftGameInvariant => build_left_invariant_new_call(&claim.name),
             ClaimType::RightGameInvariant => build_right_invariant_new_call(&claim.name),
         };
@@ -308,34 +259,28 @@ impl<'a> EquivalenceContext<'a> {
 
         for pkg in &gctx_left.game().pkgs {
             if !pkg.pkg.invariants.is_empty() {
-                dependencies_code.push(build_left_invariant_old_call(&format!(
-                    "package-invariant!{}-{}!",
-                    game_inst_name_left,
-                    pkg.name()
-                )));
+                dependencies_code.push(build_left_invariant_old_call(
+                    &names::package_invariant_fn_name(game_inst_name_left, pkg.name()),
+                ));
             }
         }
         for pkg in &gctx_right.game().pkgs {
             if !pkg.pkg.invariants.is_empty() {
-                dependencies_code.push(build_right_invariant_old_call(&format!(
-                    "package-invariant!{}-{}!",
-                    game_inst_name_right,
-                    pkg.name()
-                )));
+                dependencies_code.push(build_right_invariant_old_call(
+                    &names::package_invariant_fn_name(game_inst_name_right, pkg.name()),
+                ));
             }
         }
 
         if !gctx_left.game().invariants.is_empty() {
-            dependencies_code.push(build_left_invariant_old_call(&format!(
-                "game-invariant!{}!",
-                game_inst_name_left,
-            )));
+            dependencies_code.push(build_left_invariant_old_call(
+                &names::game_invariant_fn_name(game_inst_name_left),
+            ));
         }
         if !gctx_right.game().invariants.is_empty() {
-            dependencies_code.push(build_right_invariant_old_call(&format!(
-                "game-invariant!{}!",
-                game_inst_name_right,
-            )));
+            dependencies_code.push(build_right_invariant_old_call(
+                &names::game_invariant_fn_name(game_inst_name_right),
+            ));
         }
 
         for dep in dep_calls {
@@ -349,59 +294,20 @@ impl<'a> EquivalenceContext<'a> {
         .into()
     }
 
-    pub(crate) fn emit_game_definitions(&'a self) -> impl Iterator<Item = SmtExpr> + 'a {
-        let left = self
-            .theorem
-            .find_game_instance(self.equivalence.left_name())
-            .unwrap();
-        let right = self
-            .theorem
-            .find_game_instance(self.equivalence.right_name())
-            .unwrap();
+    pub(crate) fn emit_game_definitions(&'a self) -> Vec<SmtExpr> {
+        game_defs::emit_game_definitions(self.theorem, &self.game_instances())
+    }
 
-        let mut left_writer = CompositionSmtWriter::new(left, self.sample_info_left());
-        let mut right_writer = CompositionSmtWriter::new(right, self.sample_info_right());
-
-        left_writer
-            .smt_composition_randomness()
-            .chain(right_writer.smt_composition_randomness())
-            .chain(self.smt_package_const_definitions())
-            .chain(self.smt_package_state_definitions())
-            .chain(self.smt_theorem_const_definition())
-            .chain(self.smt_game_const_definitions())
-            .chain(self.smt_game_state_definitions())
-            .chain(self.smt_theorem_game_const_mapping_definitions())
-            .chain(self.smt_game_pkg_const_mapping_definitions())
-            .chain(self.smt_package_return_definitions())
-            .chain(self.smt_oracle_function_definitions())
+    /// The two game instances of this equivalence, paired with their sampling information.
+    fn game_instances(&'a self) -> Vec<game_defs::GameInstanceWithSampleInfo<'a>> {
+        vec![
+            (self.left_game_inst_ctx(), self.sample_info_left()),
+            (self.right_game_inst_ctx(), self.sample_info_right()),
+        ]
     }
 
     pub(crate) fn emit_base_declarations(&self) -> Vec<SmtExpr> {
-        let mut base_declarations: Vec<SmtExpr> = vec![("set-logic", "ALL").into()];
-
-        let mut bits_sort_suffixes = HashSet::new();
-
-        for ty in self.types() {
-            if let TypeKind::Bits(count_spec) = &ty.kind() {
-                let bits_sort_suffix = count_spec.resolved_suffix();
-
-                log::debug!("found {bits_sort_suffix}");
-
-                // ensure we don't write more than once. Earlier we also dedupe, but we dedupe
-                // identifiers, which contain more info than just the name.
-                if bits_sort_suffixes.insert(bits_sort_suffix.clone()) {
-                    base_declarations.extend(hacks::BitsDeclaration(bits_sort_suffix));
-                }
-            }
-        }
-
-        base_declarations.extend(hacks::MaybeDeclaration);
-        base_declarations.push(hacks::ReturnValueDeclaration.into());
-        base_declarations.extend(hacks::TuplesDeclaration(1..32));
-        base_declarations.extend(hacks::EmptyDeclaration);
-        base_declarations.push(hacks::SampleIdDeclaration.into());
-
-        base_declarations
+        game_defs::emit_base_declarations(&self.types())
     }
 
     pub(crate) fn emit_auto_randomness(&self, oracle_name: &str) -> Vec<SmtExpr> {
@@ -470,34 +376,8 @@ impl<'a> EquivalenceContext<'a> {
         }
     }
 
-    pub(crate) fn emit_theorem_paramfuncs(&'a self) -> impl Iterator<Item = SmtExpr> + 'a {
-        fn get_fn<T: Clone>(arg: &(T, Type)) -> Option<(T, Vec<Type>, Type)> {
-            let (other, ty) = arg;
-            match ty.kind() {
-                TypeKind::Fn(args, ret) => Some((other.clone(), args.to_vec(), *ret.clone())),
-                _ => None,
-            }
-        }
-
-        self.theorem
-            .consts
-            .iter()
-            .filter_map(get_fn)
-            .map(|(func_name, arg_types, ret_type)| {
-                let arg_types: SmtExpr = arg_types
-                    .into_iter()
-                    .map(|ty| ty.into())
-                    .collect::<Vec<SmtExpr>>()
-                    .into();
-
-                (
-                    "declare-fun",
-                    format!("<<func-{func_name}>>"),
-                    arg_types,
-                    ret_type,
-                )
-                    .into()
-            })
+    pub(crate) fn emit_theorem_paramfuncs(&'a self) -> Vec<SmtExpr> {
+        game_defs::emit_theorem_paramfuncs(self.theorem)
     }
 
     pub(crate) fn emit_return_value_helpers(
@@ -867,12 +747,12 @@ impl<'a> EquivalenceContext<'a> {
 
         ////// return values
 
-        for (decl_ret, constrain) in build_returns(left) {
+        for (decl_ret, constrain) in game_defs::build_returns(left) {
             out.push(decl_ret);
             out.push(constrain);
         }
 
-        for (decl_ret, constrain) in build_returns(right) {
+        for (decl_ret, constrain) in game_defs::build_returns(right) {
             out.push(decl_ret);
             out.push(constrain);
         }
@@ -880,7 +760,7 @@ impl<'a> EquivalenceContext<'a> {
         /////// randomess counters
 
         for (decl_ctr, assert_ctr, assert_zero_ctr, decl_val, assert_val) in
-            build_rands(self.sample_info_left(), left)
+            game_defs::build_rands(self.sample_info_left(), left)
         {
             out.push(decl_ctr);
             out.push(assert_ctr);
@@ -890,7 +770,7 @@ impl<'a> EquivalenceContext<'a> {
         }
 
         for (decl_ctr, assert_ctr, assert_zero_ctr, decl_val, assert_val) in
-            build_rands(self.sample_info_right(), right)
+            game_defs::build_rands(self.sample_info_right(), right)
         {
             out.push(decl_ctr);
             out.push(assert_ctr);
@@ -901,281 +781,17 @@ impl<'a> EquivalenceContext<'a> {
 
         /////////// helpers for working with randomness
 
-        out.push(self.smt_define_randctr_function(left, self.sample_info_left()));
-        out.push(self.smt_define_randctr_function(right, self.sample_info_right()));
+        out.push(game_defs::define_randctr_function(
+            left,
+            self.sample_info_left(),
+        ));
+        out.push(game_defs::define_randctr_function(
+            right,
+            self.sample_info_right(),
+        ));
         out.push(self.smt_define_randeq_function());
 
         out
-    }
-
-    /// Returns an iterator of all the package const datatypes that need to be defined for this
-    /// equivalence theorem. It makes sure to skip duplicate definitions, which may occur if a
-    /// package is used more than once.
-    pub(crate) fn smt_package_const_definitions(&'a self) -> impl Iterator<Item = SmtExpr> + 'a {
-        let mut already_defined = BTreeSet::new();
-
-        Some(self)
-            .into_iter()
-            .flat_map(|ectx| {
-                vec![ectx.left_game_inst_ctx(), ectx.right_game_inst_ctx()].into_iter()
-            })
-            .flat_map(|gctx| gctx.pkg_inst_contexts())
-            .map(|pctx| {
-                let pattern = pctx.datastructure_pkg_consts_pattern();
-                let spec = pattern.datastructure_spec(pctx.pkg());
-
-                (pattern, spec)
-            })
-            .filter_map(move |(pattern, spec)| {
-                if already_defined.insert(pattern.sort_name()) {
-                    Some(declare_datatype(&pattern, &spec))
-                } else {
-                    None
-                }
-            })
-    }
-
-    /// Returns an iterator of all the package state datatypes that need to be defined for this
-    /// equivalence theorem. It makes sure to skip duplicate definitions, which may occur if a
-    /// package is used more than once.
-    pub(crate) fn smt_package_state_definitions(&'a self) -> impl Iterator<Item = SmtExpr> + 'a {
-        let mut already_defined = BTreeSet::new();
-
-        Some(self)
-            .into_iter()
-            .flat_map(|ectx| {
-                vec![ectx.left_game_inst_ctx(), ectx.right_game_inst_ctx()].into_iter()
-            })
-            .flat_map(|gctx| gctx.pkg_inst_contexts())
-            .filter_map(move |pctx| {
-                let pattern = pctx.pkg_state_pattern();
-                let spec = pattern.datastructure_spec(pctx.pkg());
-
-                if already_defined.insert(pattern.sort_name()) {
-                    Some(declare_datatype(&pattern, &spec))
-                } else {
-                    None
-                }
-            })
-    }
-
-    /// Returns an iterator of all the package state datatypes that need to be defined for this
-    /// equivalence theorem. It makes sure to skip duplicate definitions, which may occur if a
-    /// package is used more than once.
-    pub(crate) fn smt_package_return_definitions(&'a self) -> impl Iterator<Item = SmtExpr> + 'a {
-        let mut already_defined = BTreeSet::new();
-
-        Some(self)
-            .into_iter()
-            .flat_map(|ectx| {
-                vec![ectx.left_game_inst_ctx(), ectx.right_game_inst_ctx()].into_iter()
-            })
-            .flat_map(|gctx| gctx.pkg_inst_contexts())
-            .flat_map(|pctx| pctx.oracle_contexts())
-            .filter_map(move |octx| {
-                let pattern = octx.return_pattern();
-                let spec = pattern.datastructure_spec(&octx.oracle_sig().ty);
-
-                if already_defined.insert(pattern.sort_name()) {
-                    Some(declare_datatype(&pattern, &spec))
-                } else {
-                    None
-                }
-            })
-    }
-
-    /// Returns an iterator of all the game state datatypes that need to be defined for this
-    /// equivalence theorem. It makes sure to skip duplicate definitions, which may occur if a
-    /// package is used more than once.
-    pub(crate) fn smt_game_state_definitions(&'a self) -> impl Iterator<Item = SmtExpr> + 'a {
-        let mut already_defined = BTreeSet::new();
-
-        Some(self)
-            .into_iter()
-            .flat_map(move |ectx| {
-                vec![
-                    (ectx.left_game_inst_ctx(), self.sample_info_left()),
-                    (ectx.right_game_inst_ctx(), self.sample_info_right()),
-                ]
-                .into_iter()
-            })
-            .filter_map(move |(gctx, sample_info)| {
-                let declare_info = GameStateDeclareInfo {
-                    game_inst: gctx.game_inst(),
-                    sample_info,
-                };
-
-                let pattern = gctx.datastructure_game_state_pattern();
-                let spec = pattern.datastructure_spec(&declare_info);
-
-                if already_defined.insert(pattern.sort_name()) {
-                    let datatype = declare_datatype(&pattern, &spec);
-                    Some(datatype)
-                } else {
-                    None
-                }
-            })
-    }
-
-    /// Returns an iterator cntaining the theorem const datatype.
-    pub(crate) fn smt_theorem_const_definition(&'a self) -> impl Iterator<Item = SmtExpr> + 'a {
-        let pattern = self.datastructure_theorem_consts_pattern();
-        let spec = pattern.datastructure_spec(self.theorem());
-
-        Some(declare_datatype(&pattern, &spec)).into_iter()
-    }
-
-    /// Returns an iterator of all the game const datatypes that need to be defined for this
-    /// equivalence theorem. It makes sure to skip duplicate definitions, which may occur if a
-    /// package is used more than once.
-    pub(crate) fn smt_game_const_definitions(&'a self) -> impl Iterator<Item = SmtExpr> + 'a {
-        let mut already_defined = BTreeSet::new();
-
-        Some(self)
-            .into_iter()
-            .flat_map(move |ectx| {
-                vec![ectx.left_game_inst_ctx(), ectx.right_game_inst_ctx()].into_iter()
-            })
-            .filter_map(move |gctx| {
-                let pattern = gctx.datastructure_game_consts_pattern();
-                let spec = pattern.datastructure_spec(gctx.game());
-
-                if already_defined.insert(pattern.sort_name()) {
-                    Some(declare_datatype(&pattern, &spec))
-                } else {
-                    None
-                }
-            })
-    }
-
-    /// Returns an iterator over the functions that map the constant values of the theorem to that of a
-    /// game instance. Ranges over all game instances.
-    pub(crate) fn smt_theorem_game_const_mapping_definitions(
-        &'a self,
-    ) -> impl Iterator<Item = SmtExpr> + 'a {
-        Some(self)
-            .into_iter()
-            .flat_map(move |ectx| {
-                vec![
-                    ectx.left_game_inst_ctx().game_inst(),
-                    ectx.right_game_inst_ctx().game_inst(),
-                ]
-                .into_iter()
-            })
-            .flat_map(move |game_inst| {
-                define_game_const_mapping_fun(self.theorem(), game_inst.game(), game_inst.name())
-                    .map(SmtExpr::from)
-            })
-    }
-
-    /// Returns an iterator over the functions that map the constant values of a game to that of a
-    /// package instance. Ranges over all package instances in all games.
-    pub(crate) fn smt_game_pkg_const_mapping_definitions(
-        &'a self,
-    ) -> impl Iterator<Item = SmtExpr> + 'a {
-        let mut seen_game_names: HashSet<&str> = Default::default();
-
-        Some(self)
-            .into_iter()
-            .flat_map(move |ectx| {
-                vec![ectx.left_game_inst_ctx(), ectx.right_game_inst_ctx()].into_iter()
-            })
-            .filter(move |gctx| seen_game_names.insert(gctx.game_name()))
-            .flat_map(|gctx| {
-                gctx.game().pkgs.iter().flat_map(move |pkg_inst| {
-                    define_pkg_const_mapping_fun(gctx.game(), &pkg_inst.pkg, &pkg_inst.name)
-                        .map(SmtExpr::from)
-                })
-            })
-    }
-
-    pub(crate) fn smt_oracle_function_definitions(&'a self) -> impl Iterator<Item = SmtExpr> + 'a {
-        let mut already_defined = BTreeSet::new();
-
-        Some(self)
-            .into_iter()
-            .flat_map(move |ectx| {
-                let left_gctx = ectx.left_game_inst_ctx();
-                let right_gctx = ectx.right_game_inst_ctx();
-
-                vec![
-                    (left_gctx, ectx.sample_info_left()),
-                    (right_gctx, ectx.sample_info_right()),
-                ]
-                .into_iter()
-            })
-            .flat_map(|(gctx, sample_info)| {
-                gctx.pkg_inst_contexts()
-                    .map(move |pctx| (pctx, sample_info))
-            })
-            .flat_map(|(pctx, sample_info)| {
-                pctx.oracle_contexts().map(move |octx| (octx, sample_info))
-            })
-            .filter_map(move |(octx, sample_info)| {
-                let gctx = octx.game_inst_ctx();
-                let pctx = octx.pkg_inst_ctx();
-                let pattern = octx.oracle_pattern();
-
-                let game_inst = gctx.game_inst();
-
-                let writer = CompositionSmtWriter::new(game_inst, sample_info);
-
-                if already_defined.insert(pattern.function_name()) {
-                    let fundef =
-                        writer.smt_define_nonsplit_oracle_fn(pctx.pkg_inst(), octx.oracle_def());
-                    Some(fundef)
-                } else {
-                    None
-                }
-            })
-    }
-
-    pub fn smt_define_randctr_function(
-        &self,
-        game_inst: &GameInstance,
-        sample_info: &SampleInfo,
-    ) -> SmtExpr {
-        let gctx = GameInstanceContext::new(game_inst);
-        let game = game_inst.game();
-        let game_inst_name = game_inst.name();
-        let game_name = &game.name;
-        let params = &game_inst.consts;
-
-        let state_name = gctx
-            .oracle_arg_game_state_pattern()
-            .old_global_const_name(game_inst_name);
-
-        let pattern = patterns::GameStatePattern { game_name, params };
-        let info = patterns::GameStateDeclareInfo {
-            game_inst,
-            sample_info,
-        };
-
-        let spec = pattern.datastructure_spec(&info);
-        let (_, selectors) = &spec.0[0];
-
-        let mut body = SmtExpr::Atom("0".to_string());
-
-        for selector in selectors {
-            body = match selector {
-                patterns::GameStateSelector::Randomness { sample_pos } => SmtIte {
-                    cond: ("=", "sampleid", sample_pos.as_ref()),
-                    then: (pattern.selector_name(selector), state_name.clone()),
-                    els: body,
-                }
-                .into(),
-                _ => body,
-            };
-        }
-
-        (
-            "define-fun",
-            format!("get-rand-ctr-{game_inst_name}"),
-            (("sampleid", "SampleId"),),
-            "Int",
-            body,
-        )
-            .into()
     }
 
     pub fn smt_define_randeq_function(&self) -> SmtExpr {
@@ -1315,187 +931,4 @@ impl<'a> EquivalenceContext<'a> {
         )
             .into()
     }
-}
-
-fn build_returns(game_inst: &GameInstance) -> Vec<(SmtExpr, SmtExpr)> {
-    let gctx = GameInstanceContext::new(game_inst);
-    let game_name = &game_inst.game().name;
-    let game_inst_name = &game_inst.name();
-    let game_params = &game_inst.consts;
-
-    // write declarations of right return constants and constrain them
-    let mut out = vec![];
-    for export in &game_inst.game().exports {
-        let pkg_inst = &game_inst.game().pkgs[export.to()];
-        let sig = export.sig();
-
-        let pkg_inst_name = &pkg_inst.name;
-        let pkg_params = &pkg_inst.params;
-        let pkg_name = &pkg_inst.pkg.name;
-        let oracle_name = &sig.name;
-        let oracle_import_name = export.name();
-        let return_type = &sig.ty;
-
-        let mut octx = gctx
-            .exported_oracle_ctx_by_name(export.name())
-            .unwrap_or_else(|| {
-                panic!(
-                    "error looking up exported oracle with name {oracle_name} in game {game_name}"
-                )
-            });
-        octx.set_renamed(export.alias());
-
-        let return_const = patterns::ReturnConst {
-            game_inst_name,
-            game_name,
-            game_params,
-            pkg_name,
-            pkg_params,
-            oracle_name,
-            oracle_import_name,
-        };
-
-        let return_value_const = patterns::ReturnValueConst {
-            game_inst_name,
-            pkg_inst_name,
-            oracle_name: oracle_import_name,
-            ty: &sig.ty,
-        };
-
-        let is_abort_const_pattern = ReturnIsAbortConst {
-            game_inst_name,
-            pkg_inst_name,
-            oracle_name: oracle_import_name,
-            ty: &sig.ty,
-        };
-
-        let state = octx.oracle_arg_game_state_pattern();
-        let consts = octx.oracle_arg_game_consts_pattern();
-
-        let old_state_const = state.old_global_const_name(game_inst_name);
-        let new_state_const =
-            state.new_global_const_name(game_inst_name, oracle_import_name.to_string());
-        let consts_const = consts.unit_global_const_name(game_inst_name);
-
-        let args = sig
-            .args
-            .iter()
-            .map(|(arg_name, _)| octx.smt_arg_name(arg_name));
-
-        let oracle_func_evaluation = octx
-            .smt_call_oracle_fn(old_state_const, consts_const, args)
-            .unwrap();
-
-        let return_pattern = octx.return_pattern();
-        let return_spec = return_pattern.datastructure_spec(return_type);
-
-        let access_returnvalue = return_pattern
-            .access(
-                &return_spec,
-                &patterns::ReturnSelector::ReturnValueOrAbort {
-                    return_type: &sig.ty,
-                },
-                return_const.name(),
-            )
-            .unwrap();
-
-        let access_new_state = return_pattern
-            .access(
-                &return_spec,
-                &patterns::ReturnSelector::GameState,
-                return_const.name(),
-            )
-            .unwrap();
-
-        let constrain_return = SmtAssert(SmtEq2 {
-            lhs: return_const.name(),
-            rhs: oracle_func_evaluation,
-        });
-
-        let constrain_return_value = SmtAssert(SmtEq2 {
-            lhs: return_value_const.name(),
-            rhs: access_returnvalue,
-        });
-
-        let constrain_new_state = SmtAssert(SmtEq2 {
-            lhs: new_state_const,
-            rhs: access_new_state,
-        });
-
-        let constrain_is_abort = SmtAssert(SmtEq2 {
-            lhs: is_abort_const_pattern.name(),
-            rhs: is_abort_const_pattern.value(return_value_const.name()),
-        });
-
-        out.push((return_const.declare(), constrain_return.into()));
-        out.push((return_value_const.declare(), constrain_return_value.into()));
-        out.push((is_abort_const_pattern.declare(), constrain_is_abort.into()));
-        out.push((
-            state.declare_new(game_inst_name, oracle_import_name.to_string()),
-            constrain_new_state.into(),
-        ));
-    }
-
-    out
-}
-
-fn build_rands(
-    sample_info: &SampleInfo,
-    game_inst: &GameInstance,
-) -> Vec<(SmtExpr, SmtExpr, SmtExpr, SmtExpr, SmtExpr)> {
-    let gctx = GameInstanceContext::new(game_inst);
-
-    sample_info
-        .positions
-        .iter()
-        .map(|sample_item| {
-            let sample_id = sample_item.sample_id;
-            let ty = &sample_item.ty;
-            let game_inst_name = game_inst.name();
-
-            let state = gctx
-                .oracle_arg_game_state_pattern()
-                .old_global_const_name(game_inst_name);
-
-            let randctr_name = format!("randctr-{game_inst_name}-{sample_id}");
-            let randval_name = format!("randval-{game_inst_name}-{sample_id}");
-
-            let decl_randctr = declare_const(randctr_name.clone(), Sort::Int);
-            let decl_randval = declare_const(randval_name.clone(), ty.clone().into());
-
-            // pull randomness counter for given sample_id out of the gamestate
-            let randctr = gctx
-                .smt_access_gamestate_rand(sample_info, state, sample_id)
-                .unwrap();
-
-            let constrain_randctr: SmtExpr = SmtAssert(SmtEq2 {
-                lhs: randctr_name.as_str(),
-                rhs: randctr.clone(),
-            })
-            .into();
-
-            let zero_constrain_randctr: SmtExpr = SmtAssert(SmtEq2 {
-                lhs: randctr_name.as_str(),
-                rhs: 0,
-            })
-            .into();
-
-            // apply respective randomness function (based on type) to the given counter
-            let randval = gctx.smt_eval_randfn(sample_item, ("+", 0, randctr_name.as_str()), ty);
-
-            let constrain_randval: SmtExpr = SmtAssert(SmtEq2 {
-                lhs: randval_name,
-                rhs: randval,
-            })
-            .into();
-
-            (
-                decl_randctr,
-                constrain_randctr,
-                zero_constrain_randctr,
-                decl_randval,
-                constrain_randval,
-            )
-        })
-        .collect()
 }

--- a/src/writers/smt/contexts/game_defs.rs
+++ b/src/writers/smt/contexts/game_defs.rs
@@ -1,0 +1,613 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! SMT declarations and definitions that describe one or more *game instances*.
+//!
+//! Both the equivalence prover (which works on two game instances at a time) and the package
+//! invariant prover (which works on a single, synthetic game instance) need the same set of
+//! datatype declarations, constant mapping functions and oracle function definitions. This module
+//! holds that shared code, parameterised over the list of game instances it should cover.
+
+use std::collections::{BTreeSet, HashSet};
+
+use crate::{
+    hacks,
+    identifier::{
+        theorem_ident::{TheoremConstIdentifier, TheoremIdentifier},
+        Identifier,
+    },
+    theorem::{GameInstance, Theorem},
+    transforms::samplify::SampleInfo,
+    types::{CountSpec, Type, TypeKind},
+    writers::smt::{
+        contexts::{GameInstanceContext, GenericOracleContext},
+        declare::declare_const,
+        exprs::{SmtAssert, SmtEq2, SmtExpr, SmtIte},
+        patterns::{
+            self,
+            const_mapping::{define_game_const_mapping_fun, define_pkg_const_mapping_fun},
+            datastructures::DatastructurePattern,
+            declare_datatype,
+            functions::FunctionPattern,
+            oracle_args::GameStateOracleArgPattern,
+            oracle_args::OracleArgPattern,
+            oracle_args::UnitOracleArgPattern,
+            theorem_constants::ConstantPattern,
+            GameStateDeclareInfo, ReturnIsAbortConst,
+        },
+        sorts::Sort,
+        writer::CompositionSmtWriter,
+    },
+};
+
+/// One game instance together with the sampling information that was collected for it.
+pub(crate) type GameInstanceWithSampleInfo<'a> = (GameInstanceContext<'a>, &'a SampleInfo);
+
+/// Emits the sort declarations that every proof needs: the `Bits_*` sorts occurring in `types`,
+/// plus the `Maybe`, `ReturnValue`, `TupleN`, `Empty` and `SampleId` helpers.
+pub(crate) fn emit_base_declarations(types: &[Type]) -> Vec<SmtExpr> {
+    let mut base_declarations: Vec<SmtExpr> = vec![("set-logic", "ALL").into()];
+
+    let mut bits_sort_suffixes = HashSet::new();
+
+    for ty in types {
+        if let TypeKind::Bits(count_spec) = &ty.kind() {
+            let bits_sort_suffix = count_spec.resolved_suffix();
+
+            log::debug!("found {bits_sort_suffix}");
+
+            // ensure we don't write more than once. Earlier we also dedupe, but we dedupe
+            // identifiers, which contain more info than just the name.
+            if bits_sort_suffixes.insert(bits_sort_suffix.clone()) {
+                base_declarations.extend(hacks::BitsDeclaration(bits_sort_suffix));
+            }
+        }
+    }
+
+    base_declarations.extend(hacks::MaybeDeclaration);
+    base_declarations.push(hacks::ReturnValueDeclaration.into());
+    base_declarations.extend(hacks::TuplesDeclaration(1..32));
+    base_declarations.extend(hacks::EmptyDeclaration);
+    base_declarations.push(hacks::SampleIdDeclaration.into());
+
+    base_declarations
+}
+
+/// Returns the `Bits(<theorem const>)` types induced by the integer constants of `theorem`.
+///
+/// These need to be part of the type list handed to [`emit_base_declarations`], because a
+/// `Bits(n)` sort may only show up after the package parameter `n` has been resolved to a theorem
+/// constant.
+pub(crate) fn theorem_const_bits_types(theorem: &Theorem) -> HashSet<Type> {
+    theorem
+        .consts
+        .iter()
+        .filter_map(|(name, ty)| match ty.kind() {
+            TypeKind::Integer => {
+                let id = TheoremConstIdentifier {
+                    theorem_name: theorem.name.clone(),
+                    name: name.clone(),
+                    ty: Type::integer(),
+                    inst_info: None,
+                };
+
+                Some(Type::bits(CountSpec::Identifier(Box::new(
+                    Identifier::TheoremIdentifier(TheoremIdentifier::Const(id)),
+                ))))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// Declares the function-typed theorem constants as plain SMT functions.
+///
+/// Function-typed constants are excluded from the theorem/game/package constant datatypes (see
+/// e.g. [`crate::writers::smt::patterns::theorem_consts::TheoremConstsPattern`]), so that we stay
+/// compatible with solvers without higher-order support. Instead they live in the global scope.
+pub(crate) fn emit_theorem_paramfuncs(theorem: &Theorem) -> Vec<SmtExpr> {
+    theorem
+        .consts
+        .iter()
+        .filter_map(|(name, ty)| match ty.kind() {
+            TypeKind::Fn(args, ret) => Some((name.clone(), args.to_vec(), (**ret).clone())),
+            _ => None,
+        })
+        .map(|(func_name, arg_types, ret_type)| {
+            let arg_types: SmtExpr = arg_types
+                .into_iter()
+                .map(|ty| ty.into())
+                .collect::<Vec<SmtExpr>>()
+                .into();
+
+            (
+                "declare-fun",
+                format!("<<func-{func_name}>>"),
+                arg_types,
+                ret_type,
+            )
+                .into()
+        })
+        .collect()
+}
+
+/// Emits all datatype declarations, constant mapping functions and oracle function definitions
+/// for the given game instances.
+///
+/// Definitions that would be emitted more than once (e.g. because the same package or the same
+/// game is instantiated twice) are only emitted the first time.
+pub(crate) fn emit_game_definitions<'a>(
+    theorem: &'a Theorem<'a>,
+    games: &[GameInstanceWithSampleInfo<'a>],
+) -> Vec<SmtExpr> {
+    let mut out = Vec::new();
+
+    for (gctx, sample_info) in games {
+        let mut writer = CompositionSmtWriter::new(gctx.game_inst(), sample_info);
+        out.extend(writer.smt_composition_randomness());
+    }
+
+    out.extend(smt_package_const_definitions(games));
+    out.extend(smt_package_state_definitions(games));
+    out.extend(smt_theorem_const_definition(theorem));
+    out.extend(smt_game_const_definitions(games));
+    out.extend(smt_game_state_definitions(games));
+    out.extend(smt_theorem_game_const_mapping_definitions(theorem, games));
+    out.extend(smt_game_pkg_const_mapping_definitions(games));
+    out.extend(smt_package_return_definitions(games));
+    out.extend(smt_oracle_function_definitions(games));
+
+    out
+}
+
+/// All the package const datatypes that need to be defined, skipping duplicate definitions.
+fn smt_package_const_definitions(games: &[GameInstanceWithSampleInfo]) -> Vec<SmtExpr> {
+    let mut already_defined = BTreeSet::new();
+
+    games
+        .iter()
+        .flat_map(|(gctx, _)| gctx.pkg_inst_contexts())
+        .filter_map(|pctx| {
+            let pattern = pctx.datastructure_pkg_consts_pattern();
+            let spec = pattern.datastructure_spec(pctx.pkg());
+
+            if already_defined.insert(pattern.sort_name()) {
+                Some(declare_datatype(&pattern, &spec))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// All the package state datatypes that need to be defined, skipping duplicate definitions.
+fn smt_package_state_definitions(games: &[GameInstanceWithSampleInfo]) -> Vec<SmtExpr> {
+    let mut already_defined = BTreeSet::new();
+
+    games
+        .iter()
+        .flat_map(|(gctx, _)| gctx.pkg_inst_contexts())
+        .filter_map(|pctx| {
+            let pattern = pctx.pkg_state_pattern();
+            let spec = pattern.datastructure_spec(pctx.pkg());
+
+            if already_defined.insert(pattern.sort_name()) {
+                Some(declare_datatype(&pattern, &spec))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// All the oracle return datatypes that need to be defined, skipping duplicate definitions.
+fn smt_package_return_definitions(games: &[GameInstanceWithSampleInfo]) -> Vec<SmtExpr> {
+    let mut already_defined = BTreeSet::new();
+
+    games
+        .iter()
+        .flat_map(|(gctx, _)| gctx.pkg_inst_contexts())
+        .flat_map(|pctx| pctx.oracle_contexts())
+        .filter_map(|octx| {
+            let pattern = octx.return_pattern();
+            let spec = pattern.datastructure_spec(&octx.oracle_sig().ty);
+
+            if already_defined.insert(pattern.sort_name()) {
+                Some(declare_datatype(&pattern, &spec))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// All the game state datatypes that need to be defined, skipping duplicate definitions.
+fn smt_game_state_definitions(games: &[GameInstanceWithSampleInfo]) -> Vec<SmtExpr> {
+    let mut already_defined = BTreeSet::new();
+
+    games
+        .iter()
+        .filter_map(|(gctx, sample_info)| {
+            let declare_info = GameStateDeclareInfo {
+                game_inst: gctx.game_inst(),
+                sample_info,
+            };
+
+            let pattern = gctx.datastructure_game_state_pattern();
+            let spec = pattern.datastructure_spec(&declare_info);
+
+            if already_defined.insert(pattern.sort_name()) {
+                Some(declare_datatype(&pattern, &spec))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// The theorem const datatype.
+fn smt_theorem_const_definition<'a>(theorem: &'a Theorem<'a>) -> Vec<SmtExpr> {
+    let pattern = patterns::theorem_consts::TheoremConstsPattern {
+        theorem_name: &theorem.name,
+    };
+    let spec = pattern.datastructure_spec(theorem);
+
+    vec![declare_datatype(&pattern, &spec)]
+}
+
+/// All the game const datatypes that need to be defined, skipping duplicate definitions.
+fn smt_game_const_definitions(games: &[GameInstanceWithSampleInfo]) -> Vec<SmtExpr> {
+    let mut already_defined = BTreeSet::new();
+
+    games
+        .iter()
+        .filter_map(|(gctx, _)| {
+            let pattern = gctx.datastructure_game_consts_pattern();
+            let spec = pattern.datastructure_spec(gctx.game());
+
+            if already_defined.insert(pattern.sort_name()) {
+                Some(declare_datatype(&pattern, &spec))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// The functions that map the constant values of the theorem to those of a game instance.
+fn smt_theorem_game_const_mapping_definitions<'a>(
+    theorem: &'a Theorem<'a>,
+    games: &[GameInstanceWithSampleInfo<'a>],
+) -> Vec<SmtExpr> {
+    games
+        .iter()
+        .filter_map(|(gctx, _)| {
+            let game_inst = gctx.game_inst();
+            define_game_const_mapping_fun(theorem, game_inst.game(), game_inst.name())
+                .map(SmtExpr::from)
+        })
+        .collect()
+}
+
+/// The functions that map the constant values of a game to those of its package instances.
+fn smt_game_pkg_const_mapping_definitions(games: &[GameInstanceWithSampleInfo]) -> Vec<SmtExpr> {
+    let mut seen_game_names: HashSet<&str> = Default::default();
+
+    games
+        .iter()
+        .filter(|(gctx, _)| seen_game_names.insert(gctx.game_name()))
+        .flat_map(|(gctx, _)| {
+            gctx.game().pkgs.iter().filter_map(move |pkg_inst| {
+                define_pkg_const_mapping_fun(gctx.game(), &pkg_inst.pkg, &pkg_inst.name)
+                    .map(SmtExpr::from)
+            })
+        })
+        .collect()
+}
+
+/// The oracle function definitions, skipping oracles that have already been defined.
+fn smt_oracle_function_definitions(games: &[GameInstanceWithSampleInfo]) -> Vec<SmtExpr> {
+    let mut already_defined = BTreeSet::new();
+
+    games
+        .iter()
+        .flat_map(|(gctx, sample_info)| {
+            gctx.pkg_inst_contexts()
+                .map(move |pctx| (pctx, sample_info))
+        })
+        .flat_map(|(pctx, sample_info)| pctx.oracle_contexts().map(move |octx| (octx, sample_info)))
+        .filter_map(|(octx, sample_info)| {
+            let gctx = octx.game_inst_ctx();
+            let pctx = octx.pkg_inst_ctx();
+            let pattern = octx.oracle_pattern();
+
+            let writer = CompositionSmtWriter::new(gctx.game_inst(), sample_info);
+
+            if already_defined.insert(pattern.function_name()) {
+                Some(writer.smt_define_nonsplit_oracle_fn(pctx.pkg_inst(), octx.oracle_def()))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Declares and constrains the return constants of every oracle the game instance exports.
+///
+/// For each exported oracle this yields (declaration, constraint) pairs for
+///
+///  * the return value of calling the oracle on the old game state,
+///  * the returned value (or abort marker),
+///  * whether the return is an abort, and
+///  * the new game state.
+pub(crate) fn build_returns(game_inst: &GameInstance) -> Vec<(SmtExpr, SmtExpr)> {
+    let gctx = GameInstanceContext::new(game_inst);
+    let game_name = &game_inst.game().name;
+    let game_inst_name = &game_inst.name();
+    let game_params = &game_inst.consts;
+
+    // write declarations of right return constants and constrain them
+    let mut out = vec![];
+    for export in &game_inst.game().exports {
+        let pkg_inst = &game_inst.game().pkgs[export.to()];
+        let sig = export.sig();
+
+        let pkg_inst_name = &pkg_inst.name;
+        let pkg_params = &pkg_inst.params;
+        let pkg_name = &pkg_inst.pkg.name;
+        let oracle_name = &sig.name;
+        let oracle_import_name = export.name();
+        let return_type = &sig.ty;
+
+        let mut octx = gctx
+            .exported_oracle_ctx_by_name(export.name())
+            .unwrap_or_else(|| {
+                panic!(
+                    "error looking up exported oracle with name {oracle_name} in game {game_name}"
+                )
+            });
+        octx.set_renamed(export.alias());
+
+        let return_const = patterns::ReturnConst {
+            game_inst_name,
+            game_name,
+            game_params,
+            pkg_name,
+            pkg_params,
+            oracle_name,
+            oracle_import_name,
+        };
+
+        let return_value_const = patterns::ReturnValueConst {
+            game_inst_name,
+            pkg_inst_name,
+            oracle_name: oracle_import_name,
+            ty: &sig.ty,
+        };
+
+        let is_abort_const_pattern = ReturnIsAbortConst {
+            game_inst_name,
+            pkg_inst_name,
+            oracle_name: oracle_import_name,
+            ty: &sig.ty,
+        };
+
+        let state = octx.oracle_arg_game_state_pattern();
+        let consts = octx.oracle_arg_game_consts_pattern();
+
+        let old_state_const = state.old_global_const_name(game_inst_name);
+        let new_state_const =
+            state.new_global_const_name(game_inst_name, oracle_import_name.to_string());
+        let consts_const = consts.unit_global_const_name(game_inst_name);
+
+        let args = sig
+            .args
+            .iter()
+            .map(|(arg_name, _)| octx.smt_arg_name(arg_name));
+
+        let oracle_func_evaluation = octx
+            .smt_call_oracle_fn(old_state_const, consts_const, args)
+            .unwrap();
+
+        let return_pattern = octx.return_pattern();
+        let return_spec = return_pattern.datastructure_spec(return_type);
+
+        let access_returnvalue = return_pattern
+            .access(
+                &return_spec,
+                &patterns::ReturnSelector::ReturnValueOrAbort {
+                    return_type: &sig.ty,
+                },
+                return_const.name(),
+            )
+            .unwrap();
+
+        let access_new_state = return_pattern
+            .access(
+                &return_spec,
+                &patterns::ReturnSelector::GameState,
+                return_const.name(),
+            )
+            .unwrap();
+
+        let constrain_return = SmtAssert(SmtEq2 {
+            lhs: return_const.name(),
+            rhs: oracle_func_evaluation,
+        });
+
+        let constrain_return_value = SmtAssert(SmtEq2 {
+            lhs: return_value_const.name(),
+            rhs: access_returnvalue,
+        });
+
+        let constrain_new_state = SmtAssert(SmtEq2 {
+            lhs: new_state_const,
+            rhs: access_new_state,
+        });
+
+        let constrain_is_abort = SmtAssert(SmtEq2 {
+            lhs: is_abort_const_pattern.name(),
+            rhs: is_abort_const_pattern.value(return_value_const.name()),
+        });
+
+        out.push((return_const.declare(), constrain_return.into()));
+        out.push((return_value_const.declare(), constrain_return_value.into()));
+        out.push((is_abort_const_pattern.declare(), constrain_is_abort.into()));
+        out.push((
+            state.declare_new(game_inst_name, oracle_import_name.to_string()),
+            constrain_new_state.into(),
+        ));
+    }
+
+    out
+}
+
+/// Declares and constrains the randomness counters and values of a game instance.
+///
+/// Each entry is `(declare counter, counter = state counter, counter = 0, declare value,
+/// value = randomness function applied to the counter)`. The caller decides whether it wants to
+/// use the "counter comes from the state" or the "counter is zero" constraint.
+pub(crate) fn build_rands(
+    sample_info: &SampleInfo,
+    game_inst: &GameInstance,
+) -> Vec<(SmtExpr, SmtExpr, SmtExpr, SmtExpr, SmtExpr)> {
+    let gctx = GameInstanceContext::new(game_inst);
+
+    sample_info
+        .positions
+        .iter()
+        .map(|sample_item| {
+            let sample_id = sample_item.sample_id;
+            let ty = &sample_item.ty;
+            let game_inst_name = game_inst.name();
+
+            let state = gctx
+                .oracle_arg_game_state_pattern()
+                .old_global_const_name(game_inst_name);
+
+            let randctr_name = format!("randctr-{game_inst_name}-{sample_id}");
+            let randval_name = format!("randval-{game_inst_name}-{sample_id}");
+
+            let decl_randctr = declare_const(randctr_name.clone(), Sort::Int);
+            let decl_randval = declare_const(randval_name.clone(), ty.clone().into());
+
+            // pull randomness counter for given sample_id out of the gamestate
+            let randctr = gctx
+                .smt_access_gamestate_rand(sample_info, state, sample_id)
+                .unwrap();
+
+            let constrain_randctr: SmtExpr = SmtAssert(SmtEq2 {
+                lhs: randctr_name.as_str(),
+                rhs: randctr.clone(),
+            })
+            .into();
+
+            let zero_constrain_randctr: SmtExpr = SmtAssert(SmtEq2 {
+                lhs: randctr_name.as_str(),
+                rhs: 0,
+            })
+            .into();
+
+            // apply respective randomness function (based on type) to the given counter
+            let randval = gctx.smt_eval_randfn(sample_item, ("+", 0, randctr_name.as_str()), ty);
+
+            let constrain_randval: SmtExpr = SmtAssert(SmtEq2 {
+                lhs: randval_name,
+                rhs: randval,
+            })
+            .into();
+
+            (
+                decl_randctr,
+                constrain_randctr,
+                zero_constrain_randctr,
+                decl_randval,
+                constrain_randval,
+            )
+        })
+        .collect()
+}
+
+/// Declares the initial game state constant and constrains every package state field to the
+/// default value of its type.
+pub(crate) fn emit_game_initial_state_values(gctx: GameInstanceContext) -> Vec<SmtExpr> {
+    let game_inst_name = gctx.game_inst_name();
+    let initial_state = gctx.oracle_arg_game_state_pattern().global_const_name(
+        game_inst_name,
+        &patterns::oracle_args::GameStateOracleArgVariant::Initial,
+    );
+
+    let mut out = Vec::new();
+    out.push(
+        gctx.oracle_arg_game_state_pattern()
+            .declare_initial(game_inst_name),
+    );
+
+    for pctx in gctx.pkg_inst_contexts() {
+        let pkg_state = gctx
+            .smt_access_gamestate_pkgstate(&initial_state, pctx.pkg_inst_name())
+            .unwrap();
+
+        for (field_name, field_ty, _) in &pctx.pkg().state {
+            let field = pctx
+                .smt_access_pkgstate(pkg_state.clone(), field_name)
+                .unwrap();
+
+            out.push(
+                SmtAssert(SmtEq2 {
+                    lhs: field,
+                    rhs: SmtExpr::from(&field_ty.default_expression()),
+                })
+                .into(),
+            );
+        }
+    }
+
+    out
+}
+
+pub(crate) fn define_randctr_function(
+    game_inst: &GameInstance,
+    sample_info: &SampleInfo,
+) -> SmtExpr {
+    let gctx = GameInstanceContext::new(game_inst);
+    let game = game_inst.game();
+    let game_inst_name = game_inst.name();
+    let game_name = &game.name;
+    let params = &game_inst.consts;
+
+    let state_name = gctx
+        .oracle_arg_game_state_pattern()
+        .old_global_const_name(game_inst_name);
+
+    let pattern = patterns::GameStatePattern { game_name, params };
+    let info = patterns::GameStateDeclareInfo {
+        game_inst,
+        sample_info,
+    };
+
+    let spec = pattern.datastructure_spec(&info);
+    let (_, selectors) = &spec.0[0];
+
+    let mut body = SmtExpr::Atom("0".to_string());
+
+    for selector in selectors {
+        body = match selector {
+            patterns::GameStateSelector::Randomness { sample_pos } => SmtIte {
+                cond: ("=", "sampleid", sample_pos.as_ref()),
+                then: (pattern.selector_name(selector), state_name.clone()),
+                els: body,
+            }
+            .into(),
+            _ => body,
+        };
+    }
+
+    (
+        "define-fun",
+        format!("get-rand-ctr-{game_inst_name}"),
+        (("sampleid", "SampleId"),),
+        "Int",
+        body,
+    )
+        .into()
+}

--- a/src/writers/smt/contexts/mod.rs
+++ b/src/writers/smt/contexts/mod.rs
@@ -16,6 +16,7 @@ impl GlobalContext {
 
 //mod game;
 mod equivalence;
+pub(crate) mod game_defs;
 mod game_inst;
 mod oracle;
 mod pkg_inst;

--- a/src/writers/smt/names.rs
+++ b/src/writers/smt/names.rs
@@ -17,6 +17,16 @@ pub(crate) fn fn_sample_rand_name<S: Into<SmtExpr>>(game_name: &str, rand_sort: 
     format!("__sample-rand-{}-{}", game_name, rand_sort.into())
 }
 
+/// The name of the function a `(define-package-invariant ...)` is rewritten into.
+pub(crate) fn package_invariant_fn_name(game_inst_name: &str, pkg_inst_name: &str) -> String {
+    format!("package-invariant!{game_inst_name}-{pkg_inst_name}!")
+}
+
+/// The name of the function a `(define-game-invariant ...)` is rewritten into.
+pub(crate) fn game_invariant_fn_name(game_inst_name: &str) -> String {
+    format!("game-invariant!{game_inst_name}!")
+}
+
 /// The kinds of delimiters we use when generating smtlib names
 pub(crate) trait Delimiter {
     const DELIMITER: &'static str;

--- a/test-projects/err-package-invariant-imports-stateful-env/games/G.comp.ssp
+++ b/test-projects/err-package-invariant-imports-stateful-env/games/G.comp.ssp
@@ -1,0 +1,25 @@
+composition G {
+    const n: Integer;
+
+    instance ctr = Ctr {
+        params {
+            n: n,
+        }
+    }
+
+    instance src = Src {
+        params {
+            n: n,
+        }
+    }
+
+    compose {
+        adversary: {
+            Step: ctr,
+            Peek: ctr,
+        },
+        ctr: {
+            Get: src,
+        },
+    }
+}

--- a/test-projects/err-package-invariant-imports-stateful-env/packages/Ctr.pkg.ssp
+++ b/test-projects/err-package-invariant-imports-stateful-env/packages/Ctr.pkg.ssp
@@ -1,0 +1,38 @@
+package Ctr {
+    invariant: [ ./packages/Ctr.smt2 ]
+
+    params {
+        n: Integer,
+    }
+
+    state {
+        ctr: Integer,
+        seen: Table(Integer, Bits(n)),
+        differed: Bool,
+    }
+
+    import oracles {
+        Get(x: Integer) -> Bits(n),
+    }
+
+    oracle Step(x: Integer) -> Bits(n) {
+        assert (x >= 0);
+        y <- invoke Get(x);
+        seen[ctr] <- Some(y);
+        ctr <- (ctr + 1);
+        return y;
+    }
+
+    oracle Peek() -> Integer {
+        return ctr;
+    }
+
+    oracle Twice(x: Integer) -> Bool {
+        a <- invoke Get(x);
+        b <- invoke Get(x);
+        if (a != b) {
+            differed <- true;
+        }
+        return differed;
+    }
+}

--- a/test-projects/err-package-invariant-imports-stateful-env/packages/Ctr.smt2
+++ b/test-projects/err-package-invariant-imports-stateful-env/packages/Ctr.smt2
@@ -1,0 +1,7 @@
+(define-package-invariant
+  (and
+    (>= pkg.ctr 0)
+    (not pkg.differed)
+    (forall ((i Int))
+      (=> (or (< i 0) (>= i pkg.ctr))
+          (is-mk-none (select pkg.seen i))))))

--- a/test-projects/err-package-invariant-imports-stateful-env/packages/Src.pkg.ssp
+++ b/test-projects/err-package-invariant-imports-stateful-env/packages/Src.pkg.ssp
@@ -1,0 +1,15 @@
+package Src {
+    params {
+        n: Integer,
+    }
+
+    state {
+        calls: Integer,
+    }
+
+    oracle Get(x: Integer) -> Bits(n) {
+        calls <- (calls + 1);
+        y <-$ Bits(n);
+        return y;
+    }
+}

--- a/test-projects/err-package-invariant-imports-stateful-env/theorem/invariant.smt2
+++ b/test-projects/err-package-invariant-imports-stateful-env/theorem/invariant.smt2
@@ -1,0 +1,5 @@
+(define-state-relation invariant (left right)
+  (and
+    (= left.ctr.ctr right.ctr.ctr)
+    (= left.ctr.seen right.ctr.seen)
+    (= left.src.calls right.src.calls)))

--- a/test-projects/err-package-invariant-imports-stateful-env/theorem/proof.ssp
+++ b/test-projects/err-package-invariant-imports-stateful-env/theorem/proof.ssp
@@ -1,0 +1,42 @@
+theorem Proof {
+    const n: Integer;
+
+    instance left = G {
+        params {
+            n: n,
+        }
+    }
+
+    instance right = G {
+        params {
+            n: n,
+        }
+    }
+
+    gamehops {
+        equivalence left right {
+            invariant: [
+                ./theorem/invariant.smt2
+            ]
+
+            Step: {
+                randomness: simple
+
+                lemmas {
+                    equal-aborts: []
+                    same-output:  [no-abort]
+                    invariant:    [no-abort]
+                }
+            }
+            Peek: {
+                randomness: none
+
+                lemmas {
+                    equal-aborts: []
+                    same-output:  [no-abort]
+                    invariant:    [no-abort]
+                }
+            }
+        }
+    }
+}

--- a/test-projects/test-package-invariant-imports/games/G.comp.ssp
+++ b/test-projects/test-package-invariant-imports/games/G.comp.ssp
@@ -1,0 +1,26 @@
+composition G {
+    const n: Integer;
+
+    instance ctr = Ctr {
+        params {
+            n: n,
+        }
+    }
+
+    instance src = Src {
+        params {
+            n: n,
+        }
+    }
+
+    compose {
+        adversary: {
+            Step: ctr,
+            Peek: ctr,
+            Get: ctr,
+        },
+        ctr: {
+            Get: src,
+        },
+    }
+}

--- a/test-projects/test-package-invariant-imports/packages/Ctr.pkg.ssp
+++ b/test-projects/test-package-invariant-imports/packages/Ctr.pkg.ssp
@@ -1,0 +1,34 @@
+package Ctr {
+    invariant: [ ./packages/Ctr.smt2 ]
+
+    params {
+        n: Integer,
+    }
+
+    state {
+        ctr: Integer,
+        seen: Table(Integer, Bits(n)),
+    }
+
+    import oracles {
+        Get(x: Integer) -> Bits(n),
+    }
+
+    oracle Step(x: Integer) -> Bits(n) {
+        assert (x >= 0);
+        y <- invoke Get(x);
+        seen[ctr] <- Some(y);
+        ctr <- (ctr + 1);
+        return y;
+    }
+
+    oracle Peek() -> Integer {
+        return ctr;
+    }
+
+    /* an oracle that shares its name with the one it forwards to */
+    oracle Get(x: Integer) -> Bits(n) {
+        y <- invoke Get(x);
+        return y;
+    }
+}

--- a/test-projects/test-package-invariant-imports/packages/Ctr.smt2
+++ b/test-projects/test-package-invariant-imports/packages/Ctr.smt2
@@ -1,0 +1,6 @@
+(define-package-invariant
+  (and
+    (>= pkg.ctr 0)
+    (forall ((i Int))
+      (=> (or (< i 0) (>= i pkg.ctr))
+          (is-mk-none (select pkg.seen i))))))

--- a/test-projects/test-package-invariant-imports/packages/Src.pkg.ssp
+++ b/test-projects/test-package-invariant-imports/packages/Src.pkg.ssp
@@ -1,0 +1,15 @@
+package Src {
+    params {
+        n: Integer,
+    }
+
+    state {
+        calls: Integer,
+    }
+
+    oracle Get(x: Integer) -> Bits(n) {
+        calls <- (calls + 1);
+        y <-$ Bits(n);
+        return y;
+    }
+}

--- a/test-projects/test-package-invariant-imports/theorem/invariant.smt2
+++ b/test-projects/test-package-invariant-imports/theorem/invariant.smt2
@@ -1,0 +1,5 @@
+(define-state-relation invariant (left right)
+  (and
+    (= left.ctr.ctr right.ctr.ctr)
+    (= left.ctr.seen right.ctr.seen)
+    (= left.src.calls right.src.calls)))

--- a/test-projects/test-package-invariant-imports/theorem/proof.ssp
+++ b/test-projects/test-package-invariant-imports/theorem/proof.ssp
@@ -1,0 +1,51 @@
+theorem Proof {
+    const n: Integer;
+
+    instance left = G {
+        params {
+            n: n,
+        }
+    }
+
+    instance right = G {
+        params {
+            n: n,
+        }
+    }
+
+    gamehops {
+        equivalence left right {
+            invariant: [
+                ./theorem/invariant.smt2
+            ]
+
+            Step: {
+                randomness: simple
+
+                lemmas {
+                    equal-aborts: []
+                    same-output:  [no-abort]
+                    invariant:    [no-abort]
+                }
+            }
+            Get: {
+                randomness: simple
+
+                lemmas {
+                    equal-aborts: []
+                    same-output:  [no-abort]
+                    invariant:    [no-abort]
+                }
+            }
+            Peek: {
+                randomness: none
+
+                lemmas {
+                    equal-aborts: []
+                    same-output:  [no-abort]
+                    invariant:    [no-abort]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is not ready for review but closes #425. It still needs some refactoring. 

It allows proving package invariants once and it implements the following:
- Allows proving package invariants individually even if not wired in a theorem using `domino prove --package PackageName`. Additionally, one can provide `--oracle Oracle` or `--invariant-start`.
- Recognizes whether the package is needed in the given theorem and/or equivalence and only then proves it once for all theorems and equivalences. If a theorem only consists of reduction hops, even if the package is used, it is not proved! Package invariants are not proved if the user has chosen a proof step and `--oracle` is provided.
- When a package P imports oracles, a stateful virtual package V is considered to export all oracles imported by P. The virtual package V looks like the following:
```
package V {
  params {
    ImportedOracle1: fn Bits(*), T -> Maybe((Bits(*), U))
  }
  state {
     st: Bits(*)
  }
  oracle ImportedOrace1(x: T) -> U {
    res <- ImportedOracle(st, x);
    (st, ret) <- Unwrap(res); // None models ImportedOrace1 aborting.
    return ret;
  }
}
```
- In order to reuse the existing transformations and SMT translation, we build a virtual game composing P and V and a virtual theorem to pass parameters that instantiates the virtual game. The virtual theorem does not have game hops obviously.

Disclaimer: Claude Opus has been used for refactoring.